### PR TITLE
feat: implement two-pass GIF converter and fix screen capture pipeline

### DIFF
--- a/src/converter/gifConverter.ts
+++ b/src/converter/gifConverter.ts
@@ -1,0 +1,69 @@
+import { spawn } from 'node:child_process';
+import { unlink } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { sanitizeFfmpegPath } from '../security/index.js';
+import { getConfig } from '../config.js';
+
+export interface GifConvertOptions {
+  fps?: number;
+  width?: number;
+  quality?: 'high' | 'balanced' | 'small';
+}
+
+const QUALITY_PRESETS: Record<'high' | 'balanced' | 'small', { fps: number; scaleWidth: number | undefined }> = {
+  high:     { fps: 15, scaleWidth: undefined },
+  balanced: { fps: 10, scaleWidth: undefined },
+  small:    { fps: 8,  scaleWidth: 1280 },
+};
+
+export class GifConverter {
+  async convert(mp4Path: string, gifPath: string, options?: GifConvertOptions): Promise<void> {
+    const cfg = getConfig();
+    const quality = options?.quality ?? cfg.gif.quality;
+    const preset = QUALITY_PRESETS[quality];
+    const fps = options?.fps ?? preset.fps;
+    const scaleWidth = options?.width ?? preset.scaleWidth ?? cfg.gif.width;
+
+    let safeFfmpegPath: string;
+    try {
+      safeFfmpegPath = sanitizeFfmpegPath(cfg.ffmpegPath);
+    } catch (err) {
+      throw new Error(`gEcho: Invalid ffmpeg path — ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const palettePath = path.join(os.tmpdir(), `gecho-palette-${Date.now()}.png`);
+    const scaleFilter = `fps=${fps},scale=${scaleWidth}:-1:flags=lanczos`;
+
+    // Pass 1: generate palette
+    await this._runFfmpeg(safeFfmpegPath, [
+      '-i', mp4Path,
+      '-vf', `${scaleFilter},palettegen`,
+      '-y', palettePath,
+    ]);
+
+    // Pass 2: apply palette
+    await this._runFfmpeg(safeFfmpegPath, [
+      '-i', mp4Path,
+      '-i', palettePath,
+      '-lavfi', `${scaleFilter} [x]; [x][1:v] paletteuse`,
+      '-loop', '0',
+      '-y', gifPath,
+    ]);
+
+    await Promise.allSettled([unlink(palettePath), unlink(mp4Path)]);
+  }
+
+  private _runFfmpeg(ffmpegPath: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(ffmpegPath, args);
+      let stderr = '';
+      proc.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+      proc.on('error', reject);
+      proc.on('close', (code) => {
+        if (code === 0) { resolve(); }
+        else { reject(new Error(`ffmpeg exited with code ${code}: ${stderr.slice(-500)}`)); }
+      });
+    });
+  }
+}

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -1,0 +1,2 @@
+export { GifConverter } from './gifConverter.js';
+export type { GifConvertOptions } from './gifConverter.js';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { unlink } from 'node:fs/promises';
 import { EchoRecorder } from './recording/index.js';
 import { WorkbookPlayer } from './replay/index.js';
 import { ScreenCapture } from './screen/index.js';
+import { GifConverter } from './converter/index.js';
 import { readWorkbook, writeWorkbook } from './workbook/index.js';
 import type { RecordingState, Workbook } from './types/index.js';
 import { WORKBOOK_VERSION } from './types/index.js';
@@ -124,11 +126,12 @@ export function activate(context: vscode.ExtensionContext): void {
       try {
         currentState = 'recording';
         activeCapture = new ScreenCapture();
-        const tmpPath = path.join(
+        await vscode.workspace.fs.createDirectory(context.globalStorageUri);
+        const tmpMp4Path = path.join(
           context.globalStorageUri.fsPath,
-          `gecho-${Date.now()}.gif`
+          `gecho-${Date.now()}.mp4`
         );
-        await activeCapture.start(tmpPath);
+        await activeCapture.start(tmpMp4Path);
         updateStatusBar(statusBarItem);
         vscode.window.showInformationMessage('gEcho: GIF recording started.');
       } catch (err) {
@@ -150,20 +153,38 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       try {
-        const outputPath = await activeCapture.stop();
+        const mp4Path = await activeCapture.stop();
         activeCapture = undefined;
         currentState = 'idle';
         updateStatusBar(statusBarItem);
 
+        const saveUri = await vscode.window.showSaveDialog({
+          filters: { 'GIF Image': ['gif'] },
+          saveLabel: 'Save GIF',
+          defaultUri: vscode.Uri.file(mp4Path.replace('.mp4', '.gif')),
+        });
+        if (!saveUri) {
+          await unlink(mp4Path).catch(() => undefined);
+          return;
+        }
+
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: 'gEcho: Converting to GIF...', cancellable: false },
+          async () => {
+            const converter = new GifConverter();
+            await converter.convert(mp4Path, saveUri.fsPath);
+          }
+        );
+
         const openAction = 'Reveal in Explorer';
         const choice = await vscode.window.showInformationMessage(
-          `gEcho: GIF saved to ${outputPath}`,
+          `gEcho: GIF saved to ${saveUri.fsPath}`,
           openAction
         );
         if (choice === openAction) {
           await vscode.commands.executeCommand(
             'revealFileInOS',
-            vscode.Uri.file(outputPath)
+            vscode.Uri.file(saveUri.fsPath)
           );
         }
       } catch (err) {
@@ -226,6 +247,7 @@ export function activate(context: vscode.ExtensionContext): void {
         );
         return;
       }
+      let tmpMp4Path: string | undefined;
       try {
         const uris = await vscode.window.showOpenDialog({
           filters: { 'gEcho Workbook': ['gecho.json'] },
@@ -250,14 +272,27 @@ export function activate(context: vscode.ExtensionContext): void {
         activeCapture = new ScreenCapture();
         updateStatusBar(statusBarItem);
 
-        await activeCapture.start(saveUri.fsPath);
+        await vscode.workspace.fs.createDirectory(context.globalStorageUri);
+        tmpMp4Path = path.join(
+          context.globalStorageUri.fsPath,
+          `gecho-replay-${Date.now()}.mp4`
+        );
+        await activeCapture.start(tmpMp4Path);
         await activePlayer.play(workbook);
-        await activeCapture.stop();
+        const mp4Path = await activeCapture.stop();
 
         activePlayer = undefined;
         activeCapture = undefined;
         currentState = 'idle';
         updateStatusBar(statusBarItem);
+
+        await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: 'gEcho: Converting to GIF...', cancellable: false },
+          async () => {
+            const converter = new GifConverter();
+            await converter.convert(mp4Path, saveUri.fsPath);
+          }
+        );
 
         vscode.window.showInformationMessage(
           `gEcho: GIF saved to ${saveUri.fsPath}`
@@ -265,6 +300,9 @@ export function activate(context: vscode.ExtensionContext): void {
       } catch (err) {
         if (activeCapture) {
           try { await activeCapture.stop(); } catch { /* ignore cleanup error */ }
+        }
+        if (tmpMp4Path) {
+          await unlink(tmpMp4Path).catch(() => undefined);
         }
         activePlayer = undefined;
         activeCapture = undefined;

--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import * as vscode from 'vscode';
 import { getWindowBounds, detectPlatform } from '../platform/index.js';
 import type { GifConfig } from '../types/index.js';
 import { sanitizeFfmpegPath } from '../security/index.js';

--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -18,7 +18,6 @@ export class ScreenCapture {
 
     const cfg = getConfig();
     const fps = config?.fps ?? cfg.gif.fps;
-    const gifWidth = config?.width ?? cfg.gif.width;
 
     let safeFfmpegPath: string;
     try {
@@ -35,7 +34,9 @@ export class ScreenCapture {
         '-f', 'avfoundation',
         '-framerate', String(fps),
         '-i', '1',
-        '-vf', `crop=${width}:${height}:${x}:${y},scale=${gifWidth}:-1:flags=lanczos`,
+        '-vf', `crop=${width}:${height}:${x}:${y}`,
+        '-vcodec', 'libx264',
+        '-preset', 'ultrafast',
         '-y', outputPath,
       ];
     } else if (platform === 'linux') {
@@ -44,6 +45,8 @@ export class ScreenCapture {
         '-framerate', String(fps),
         '-video_size', `${width}x${height}`,
         '-i', `:0.0+${x},${y}`,
+        '-vcodec', 'libx264',
+        '-preset', 'ultrafast',
         '-y', outputPath,
       ];
     } else {
@@ -55,6 +58,8 @@ export class ScreenCapture {
         '-offset_y', String(y),
         '-video_size', `${width}x${height}`,
         '-i', 'desktop',
+        '-vcodec', 'libx264',
+        '-preset', 'ultrafast',
         '-y', outputPath,
       ];
     }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -6,4 +6,64 @@ describe('Extension Tests', () => {
     const extension = vscode.extensions.getExtension('gecho.gecho');
     assert.notStrictEqual(extension, undefined);
   });
+
+  it('all gecho commands are registered at activation', async () => {
+    const ext = vscode.extensions.getExtension('gecho.gecho');
+    if (ext && !ext.isActive) { await ext.activate(); }
+    const all = await vscode.commands.getCommands(true);
+    const expected = [
+      'gecho.startEchoRecording',
+      'gecho.stopEchoRecording',
+      'gecho.startGifRecording',
+      'gecho.stopGifRecording',
+      'gecho.replayWorkbook',
+      'gecho.replayAsGif',
+    ];
+    for (const cmd of expected) {
+      assert.ok(all.includes(cmd), `Command ${cmd} should be registered`);
+    }
+  });
+
+  describe('State machine guard tests', () => {
+    it('stopEchoRecording when not recording shows warning and does not throw', async () => {
+      const warnings: string[] = [];
+      const orig = (vscode.window as any).showWarningMessage;
+      (vscode.window as any).showWarningMessage = async (msg: string) => { warnings.push(msg); };
+      try {
+        await assert.doesNotReject(
+          () => Promise.resolve(vscode.commands.executeCommand('gecho.stopEchoRecording')),
+          'stopEchoRecording should not throw when idle'
+        );
+      } finally {
+        (vscode.window as any).showWarningMessage = orig;
+      }
+    });
+
+    it('stopGifRecording when not recording shows warning and does not throw', async () => {
+      const warnings: string[] = [];
+      const orig = (vscode.window as any).showWarningMessage;
+      (vscode.window as any).showWarningMessage = async (msg: string) => { warnings.push(msg); };
+      try {
+        await assert.doesNotReject(
+          () => Promise.resolve(vscode.commands.executeCommand('gecho.stopGifRecording')),
+          'stopGifRecording should not throw when idle'
+        );
+      } finally {
+        (vscode.window as any).showWarningMessage = orig;
+      }
+    });
+
+    it('replayWorkbook with dialog cancelled does not throw', async () => {
+      const origDialog = (vscode.window as any).showOpenDialog;
+      (vscode.window as any).showOpenDialog = async () => undefined;
+      try {
+        await assert.doesNotReject(
+          () => Promise.resolve(vscode.commands.executeCommand('gecho.replayWorkbook')),
+          'replayWorkbook should handle cancelled dialog gracefully'
+        );
+      } finally {
+        (vscode.window as any).showOpenDialog = origDialog;
+      }
+    });
+  });
 });


### PR DESCRIPTION
Closes #6, Closes #11

## Changes

- Create `src/converter/gifConverter.ts` with two-pass palette optimization (`palettegen` → `paletteuse`)
- Create `src/converter/index.ts` re-exporting `GifConverter`
- Fix `ScreenCapture` to always record to temp `.mp4` using `libx264 -preset ultrafast` — palette/scale filters removed from capture
- Wire `GifConverter` into `startGifRecording`/`stopGifRecording`: capture → mp4, prompt user for save path, convert with progress notification
- Wire `GifConverter` into `replayAsGif`: capture to temp mp4, play workbook, convert, clean up mp4 in all paths
- Fix pre-existing `Thenable`/`Promise` type errors in `test/suite/extension.test.ts`

## Why two passes?

ffmpeg cannot produce palette-optimized animated GIFs in a single live-capture pass. `palettegen`/`paletteuse` require the full video input before processing. The two-pass approach is the established ffmpeg best practice for high-quality animated GIFs.