### PR TITLE
fix(ci): improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - run: npm ci
+
+      - run: npm run lint
 
       - run: npm run compile
 


### PR DESCRIPTION
- Bump Node.js from 18 to 20 (matches CI, required for vsce/undici)
- Add `npm run lint` step before package to catch issues early

Partially closes #10