### PR TITLE
ci: allow dependabot conventional commit scopes in PR title validation

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -42,6 +42,10 @@ jobs:
             security
             ci
             release
+            deps
+            deps-dev
+            deps-peer
+            github-actions
           requireScope: false
           subjectPattern: ^.{10,}$
           subjectPatternError: |


### PR DESCRIPTION
Add `deps`, `deps-dev`, `deps-peer`, and `github-actions` scopes to the allowed list in `validate-pr-title.yml` so Dependabot PRs pass the PR title validation check.