### PR TITLE
fix: use editor.edit() for paste step to avoid macOS clipboard race condition

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -42,6 +42,10 @@ jobs:
             security
             ci
             release
+            deps
+            deps-dev
+            deps-peer
+            github-actions
           requireScope: false
           subjectPattern: ^.{10,}$
           subjectPatternError: |

--- a/src/replay/player.ts
+++ b/src/replay/player.ts
@@ -126,9 +126,12 @@ export class WorkbookPlayer {
         case 'paste': {
           const editor = vscode.window.activeTextEditor;
           if (editor) {
-            await editor.edit(editBuilder => {
+            const applied = await editor.edit(editBuilder => {
               editBuilder.replace(editor.selection, step.text);
             });
+            if (!applied) {
+              vscode.window.showWarningMessage('gEcho: Paste step could not be applied — edit was rejected (document may be read-only).');
+            }
           }
           break;
         }

--- a/src/replay/player.ts
+++ b/src/replay/player.ts
@@ -124,12 +124,11 @@ export class WorkbookPlayer {
         }
 
         case 'paste': {
-          const previousClipboardText = await vscode.env.clipboard.readText();
-          try {
-            await vscode.env.clipboard.writeText(step.text);
-            await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
-          } finally {
-            await vscode.env.clipboard.writeText(previousClipboardText);
+          const editor = vscode.window.activeTextEditor;
+          if (editor) {
+            await editor.edit(editBuilder => {
+              editBuilder.replace(editor.selection, step.text);
+            });
           }
           break;
         }

--- a/test/suite/player.test.ts
+++ b/test/suite/player.test.ts
@@ -193,44 +193,15 @@ describe('WorkbookPlayer', () => {
       );
     });
 
-    it('paste step writes to clipboard then calls clipboardPasteAction', async () => {
-      const calls: Array<{ cmd: string; args: any }> = [];
-      const origExec = (vscode.commands as any).executeCommand;
-      // vscode.env.clipboard is a getter-only property on Linux, so direct assignment throws.
-      // Use Object.defineProperty to override it, then restore the original descriptor.
-      const origClipboardDescriptor = Object.getOwnPropertyDescriptor(vscode.env, 'clipboard')
-        ?? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(vscode.env), 'clipboard');
-      const origClipboard = vscode.env.clipboard;
-      let clipboardText = '';
-      // Track all writes so we can verify the paste write happened even though
-      // the player restores the clipboard in its finally block.
-      const writtenTexts: string[] = [];
-      const mockClipboard = {
-        writeText: async (t: string) => { clipboardText = t; writtenTexts.push(t); },
-        readText: async () => clipboardText,
-      };
-      Object.defineProperty(vscode.env, 'clipboard', { value: mockClipboard, configurable: true, writable: true });
-      (vscode.commands as any).executeCommand = async (cmd: string, args: any) => { calls.push({ cmd, args }); };
-      try {
-        const player = new WorkbookPlayer();
-        await player.play({
+    it('paste step does not throw when no active editor', async () => {
+      // activeTextEditor is undefined in plain test host — step is silently skipped
+      const player = new WorkbookPlayer();
+      await assert.doesNotReject(() =>
+        player.play({
           version: '1.0', metadata: { name: 't' },
           steps: [{ type: 'paste', text: 'clipboard content' }],
-        });
-        // Player writes text then restores clipboard — check the write happened in order.
-        assert.strictEqual(writtenTexts[0], 'clipboard content', 'Should write to clipboard before paste');
-        assert.strictEqual(calls.length, 1);
-        assert.strictEqual(calls[0].cmd, 'editor.action.clipboardPasteAction');
-        // Clipboard should be restored to its original value (empty string) after paste.
-        assert.strictEqual(clipboardText, '', 'Clipboard should be restored after paste');
-      } finally {
-        if (origClipboardDescriptor) {
-          Object.defineProperty(vscode.env, 'clipboard', origClipboardDescriptor);
-        } else {
-          Object.defineProperty(vscode.env, 'clipboard', { value: origClipboard, configurable: true, writable: true });
-        }
-        (vscode.commands as any).executeCommand = origExec;
-      }
+        })
+      );
     });
 
     it('scroll step calls editorScroll with correct direction and lines', async () => {


### PR DESCRIPTION
## Problem

On macOS, the integration test `paste step - inserts paste text into the active editor` was failing with:

```
AssertionError [ERR_ASSERTION]: Expected "pasted-content" in document, got: ""
```

## Root cause

The original implementation:
1. Wrote the paste text to the VS Code clipboard
2. Called `editor.action.clipboardPasteAction`
3. Restored the clipboard in a `finally` block

On macOS, `clipboardPasteAction` reads the system clipboard asynchronously. Even though `executeCommand` was awaited, the command promise resolved before the clipboard was actually read — the `finally` block then restored the clipboard to empty, leaving nothing to paste.

## Fix

Replace the clipboard-based approach with a direct `editor.edit()` call that inserts the text at the current selection. This is synchronous, platform-agnostic, and produces the same end result for replay purposes.

Updated the unit test to match the new behavior: paste step silently skips when there is no active editor (consistent with the `select` step pattern). The integration test already covers the actual text-insertion case.