### PR TITLE
fix(capture): use native 60fps for avfoundation input, downsample via fps filter

### DIFF
--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -30,12 +30,16 @@ export class ScreenCapture {
     const platform = detectPlatform();
     let args: string[];
 
+    // AVFoundation requires the input framerate to exactly match a supported device mode.
+    // We capture at the native rate and downsample to the desired fps via the fps filter.
+    const AVFOUNDATION_NATIVE_FRAMERATE = 60;
+
     if (platform === 'darwin') {
       args = [
         '-f', 'avfoundation',
-        '-framerate', String(fps),
+        '-framerate', String(AVFOUNDATION_NATIVE_FRAMERATE),
         '-i', '1',
-        '-vf', `crop=${width}:${height}:${x}:${y}`,
+        '-vf', `fps=${fps},crop=${width}:${height}:${x}:${y}`,
         '-vcodec', 'libx264',
         '-preset', 'ultrafast',
         '-y', outputPath,


### PR DESCRIPTION
## Problem

macOS AVFoundation capture device requires the input `-framerate` to exactly match one of the device's supported hardware modes (e.g. `1920x1080@60fps`). Passing the user-configured output fps (e.g. `10fps`) causes ffmpeg to exit with code 251:

```
[in#0 @ ...] Selected framerate (10.000000) is not supported by the device.
[in#0 @ ...] Supported modes:
[in#0 @ ...] 1920x1080@[60.000000 60.000000]fps
Error opening input file 1.
```

## Fix

In `src/screen/capture.ts`, the macOS `avfoundation` branch now:
1. **Captures at the native device framerate** (`AVFOUNDATION_NATIVE_FRAMERATE = 60`) as the input `-framerate`
2. **Downsamples to the configured output fps** by prepending `fps=${fps},` to the `-vf` filter chain

```
ffmpeg -f avfoundation -framerate 60 -i 1   -vf "fps=10,crop=W:H:X:Y"   -vcodec libx264 -preset ultrafast output.mp4
```

Linux (`x11grab`) and Windows (`gdigrab`) accept arbitrary framerates natively — they are unchanged.

## Testing
- TypeScript compiles clean (`npm run compile`)
- macOS: ffmpeg no longer exits 251 when `gif.fps` is set below the device's native framerate
- Linux/Windows: behaviour unchanged