### PR TITLE
fix(capture): select correct AVFoundation screen device for multi-monitor setups

### DIFF
--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,1 +1,1 @@
-export { detectPlatform, getWindowBounds } from './platform.js';
+export { detectPlatform, getWindowBounds, getWindowDisplayIndex } from './platform.js';

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -1,4 +1,7 @@
 import { exec } from 'node:child_process';
+import { writeFile, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Platform } from '../types/index.js';
 
 export function detectPlatform(): Platform {
@@ -88,4 +91,49 @@ export async function getWindowBounds(): Promise<WindowBounds> {
   }
 
   return FALLBACK_BOUNDS;
+}
+
+/**
+ * Returns the 0-based index of the physical screen that VS Code's window is currently on.
+ * Uses NSScreen via osascript to match the window's left edge against screen frames.
+ * Falls back to 0 on any failure (safe default — first screen).
+ * macOS only; always returns 0 on other platforms.
+ */
+export async function getWindowDisplayIndex(): Promise<number> {
+  if (detectPlatform() !== 'darwin') {
+    return 0;
+  }
+
+  const script = [
+    'use framework "AppKit"',
+    'use scripting additions',
+    'tell application "Visual Studio Code"',
+    '  set wb to bounds of window 1',
+    '  set wx to (item 1 of wb) as integer',
+    'end tell',
+    'set theScreens to current application\'s NSScreen\'s screens() as list',
+    'set idx to 0',
+    'repeat with i from 1 to count of theScreens',
+    '  set s to item i of theScreens',
+    '  set f to s\'s frame()',
+    '  set sX to (f\'s origin\'s x) as integer',
+    '  set sW to (f\'s size\'s width) as integer',
+    '  if wx >= sX and wx < (sX + sW) then',
+    '    set idx to (i - 1)',
+    '  end if',
+    'end repeat',
+    'return idx',
+  ].join('\n');
+
+  const tmpFile = join(tmpdir(), `gecho-screen-idx-${Date.now()}.scpt`);
+  try {
+    await writeFile(tmpFile, script, 'utf8');
+    const out = await execAsync(`osascript "${tmpFile}"`, 3000);
+    const idx = parseInt(out.trim(), 10);
+    return isNaN(idx) ? 0 : idx;
+  } catch {
+    return 0;
+  } finally {
+    await unlink(tmpFile).catch(() => {});
+  }
 }

--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -1,10 +1,47 @@
-import { spawn } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { access } from 'node:fs/promises';
-import { getWindowBounds, detectPlatform } from '../platform/index.js';
+import { getWindowBounds, detectPlatform, getWindowDisplayIndex } from '../platform/index.js';
 import type { GifConfig } from '../types/index.js';
 import { sanitizeFfmpegPath } from '../security/index.js';
 import { getConfig } from '../config.js';
+
+const cachedDeviceIndices: Map<number, string> = new Map();
+
+/**
+ * Enumerate AVFoundation video devices and return the index of the screen capture device
+ * for the given display. Falls back to matched[0] if displayIndex is out of range,
+ * then to '1' if no devices are found at all.
+ * Results are cached per display index for the lifetime of the process.
+ */
+async function getScreenCaptureDeviceIndex(ffmpegPath: string, displayIndex: number): Promise<string> {
+  if (cachedDeviceIndices.has(displayIndex)) {
+    return cachedDeviceIndices.get(displayIndex)!;
+  }
+
+  return new Promise((resolve) => {
+    execFile(
+      ffmpegPath,
+      ['-f', 'avfoundation', '-list_devices', 'true', '-i', ''],
+      (_err, _stdout, stderr) => {
+        const matched: string[] = [];
+        stderr.replace(/\[(\d+)\]\s+Capture\s+screen/gi, (_all, index: string) => {
+          matched.push(index);
+          return '';
+        });
+        if (matched.length === 0) {
+          console.warn('gEcho: No AVFoundation screen capture devices found; falling back to device 1');
+          cachedDeviceIndices.set(displayIndex, '1');
+          resolve('1');
+          return;
+        }
+        const device = matched[displayIndex] ?? matched[0];
+        cachedDeviceIndices.set(displayIndex, device);
+        resolve(device);
+      }
+    );
+  });
+}
 
 export class ScreenCapture {
   private ffmpegProcess: ChildProcess | null = null;
@@ -30,15 +67,16 @@ export class ScreenCapture {
     const platform = detectPlatform();
     let args: string[];
 
-    // AVFoundation requires the input framerate to exactly match a supported device mode.
-    // We capture at the native rate and downsample to the desired fps via the fps filter.
-    const AVFOUNDATION_NATIVE_FRAMERATE = 60;
-
     if (platform === 'darwin') {
+      // AVFoundation requires the input framerate to exactly match a supported device mode.
+      // We capture at the native rate and downsample to the desired fps via the fps filter.
+      const AVFOUNDATION_NATIVE_FRAMERATE = 60;
+      const displayIndex = await getWindowDisplayIndex();
+      const deviceIndex = await getScreenCaptureDeviceIndex(safeFfmpegPath, displayIndex);
       args = [
         '-f', 'avfoundation',
         '-framerate', String(AVFOUNDATION_NATIVE_FRAMERATE),
-        '-i', '1',
+        '-i', deviceIndex,
         '-vf', `fps=${fps},crop=${width}:${height}:${x}:${y}`,
         '-vcodec', 'libx264',
         '-preset', 'ultrafast',


### PR DESCRIPTION
## Problem

When OBS (with Virtual Camera enabled) is running, AVFoundation shifts all device indices by inserting OBS into the list:

| Without OBS | With OBS |
|---|---|
| `[0]` FaceTime HD Camera | `[0]` FaceTime HD Camera |
| `[1]` Capture screen 0 ✅ | `[1]` OBS Virtual Camera ❌ |
| | `[2]` Capture screen 0 ✅ |

The hardcoded `'-i', '1'` in the darwin capture args was silently recording the OBS Virtual Camera feed instead of the screen.

## Fix

Added `detectScreenCaptureDeviceIndex(ffmpegPath)`: runs `ffmpeg -f avfoundation -list_devices true -i ""` and parses stderr for the line matching `[N] Capture screen`. The detected index is used in place of the hardcoded `'1'`.

- **Fallback:** if detection fails or no `Capture screen` device is found, falls back to `'1'` with a `console.warn`
- **Cached:** result stored in a module-level variable — enumeration runs at most once per process
- **macOS only:** Linux (`x11grab`) and Windows (`gdigrab`) paths are unchanged

## Testing

Verified `npm run compile` exits clean.