### PR TITLE
fix(capture): detect macOS screen recording permission and warn user

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { unlink } from 'node:fs/promises';
 import { EchoRecorder } from './recording/index.js';
 import { EchoPlayer } from './replay/index.js';
-import { ScreenCapture } from './screen/index.js';
+import { ScreenCapture, checkScreenRecordingPermission } from './screen/index.js';
 import { GifConverter } from './converter/index.js';
 import { readEcho, writeEcho } from './echo/index.js';
 import { createStatusBar, updateStatusBar } from './ui/index.js';
@@ -19,6 +19,25 @@ let activeCapture: ScreenCapture | undefined;
 export function activate(context: vscode.ExtensionContext): void {
   // Check for required external dependencies (e.g. ffmpeg) in the background
   checkDependencies();
+
+  // On macOS, proactively verify Screen Recording permission so the user is warned
+  // before they try to start a GIF recording.
+  if (process.platform === 'darwin') {
+    checkScreenRecordingPermission().then((result) => {
+      if (!result.granted) {
+        vscode.window.showErrorMessage(
+          'gEcho: Screen Recording permission not granted. Enable VS Code in System Settings → Privacy & Security → Screen Recording, then restart VS Code.',
+          'Open System Settings'
+        ).then((choice) => {
+          if (choice === 'Open System Settings') {
+            vscode.env.openExternal(
+              vscode.Uri.parse('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture')
+            );
+          }
+        });
+      }
+    }).catch(() => undefined);
+  }
 
   const statusBar = createStatusBar(context);
 

--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -7,31 +7,40 @@ import { sanitizeFfmpegPath } from '../security/index.js';
 import { getConfig } from '../config.js';
 
 const cachedDeviceIndices: Map<number, string> = new Map();
-let cachedAvfDevices: string[] | null = null;
+let avfDeviceEnumeration: Promise<string[]> | null = null;
 
 /**
  * Run `ffmpeg -list_devices` once and return the indices of all "Capture screen" devices.
- * Result is cached for the lifetime of the process to avoid redundant ffmpeg invocations.
+ * Result is cached as an in-flight Promise so concurrent callers share the same invocation.
+ * Spawn errors (ENOENT, EACCES) are not cached — callers may retry after fixing the path.
  */
-async function enumerateAvfDevices(ffmpegPath: string): Promise<string[]> {
-  if (cachedAvfDevices !== null) {
-    return cachedAvfDevices;
+function enumerateAvfDevices(ffmpegPath: string): Promise<string[]> {
+  if (avfDeviceEnumeration) {
+    return avfDeviceEnumeration;
   }
-  return new Promise((resolve) => {
+  avfDeviceEnumeration = new Promise((resolve, reject) => {
     execFile(
       ffmpegPath,
       ['-f', 'avfoundation', '-list_devices', 'true', '-i', ''],
-      (_err, _stdout, stderr) => {
+      (err, _stdout, stderr) => {
+        // ENOENT / EACCES mean ffmpeg itself could not be executed — not a permission issue.
+        // Clear the cache so callers can retry once the path is fixed.
+        if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
+          avfDeviceEnumeration = null;
+          reject(new Error(`gEcho: Failed to enumerate AVFoundation devices — ${err.message}`));
+          return;
+        }
+        // ffmpeg always exits non-zero when given `-i ""` — that is expected. Parse stderr.
         const matched: string[] = [];
         stderr.replace(/\[(\d+)\]\s+Capture\s+screen/gi, (_all, index: string) => {
           matched.push(index);
           return '';
         });
-        cachedAvfDevices = matched;
         resolve(matched);
       }
     );
   });
+  return avfDeviceEnumeration;
 }
 
 /**
@@ -109,7 +118,7 @@ export class ScreenCapture {
       const perm = await checkScreenRecordingPermission(safeFfmpegPath);
       if (!perm.granted) {
         throw new Error(
-          'Screen Recording permission not granted. ' +
+          'gEcho: Screen Recording permission not granted. ' +
           'Open System Settings → Privacy & Security → Screen Recording and enable VS Code, then restart VS Code.'
         );
       }

--- a/src/screen/capture.ts
+++ b/src/screen/capture.ts
@@ -7,6 +7,58 @@ import { sanitizeFfmpegPath } from '../security/index.js';
 import { getConfig } from '../config.js';
 
 const cachedDeviceIndices: Map<number, string> = new Map();
+let cachedAvfDevices: string[] | null = null;
+
+/**
+ * Run `ffmpeg -list_devices` once and return the indices of all "Capture screen" devices.
+ * Result is cached for the lifetime of the process to avoid redundant ffmpeg invocations.
+ */
+async function enumerateAvfDevices(ffmpegPath: string): Promise<string[]> {
+  if (cachedAvfDevices !== null) {
+    return cachedAvfDevices;
+  }
+  return new Promise((resolve) => {
+    execFile(
+      ffmpegPath,
+      ['-f', 'avfoundation', '-list_devices', 'true', '-i', ''],
+      (_err, _stdout, stderr) => {
+        const matched: string[] = [];
+        stderr.replace(/\[(\d+)\]\s+Capture\s+screen/gi, (_all, index: string) => {
+          matched.push(index);
+          return '';
+        });
+        cachedAvfDevices = matched;
+        resolve(matched);
+      }
+    );
+  });
+}
+
+/**
+ * Check whether macOS Screen Recording permission has been granted.
+ * AVFoundation only lists "Capture screen" devices when the permission is active;
+ * an empty device list is a reliable signal that the permission is missing.
+ *
+ * On non-darwin platforms this always returns `{ granted: true, deviceCount: 0 }`.
+ *
+ * @param ffmpegPath Optional resolved ffmpeg path. Reads from config when omitted.
+ */
+export async function checkScreenRecordingPermission(
+  ffmpegPath?: string
+): Promise<{ granted: boolean; deviceCount: number }> {
+  if (process.platform !== 'darwin') {
+    return { granted: true, deviceCount: 0 };
+  }
+  let resolvedPath: string;
+  try {
+    resolvedPath = ffmpegPath ?? sanitizeFfmpegPath(getConfig().ffmpegPath);
+  } catch {
+    // Can't validate without a working ffmpeg path — don't block.
+    return { granted: true, deviceCount: 0 };
+  }
+  const devices = await enumerateAvfDevices(resolvedPath);
+  return { granted: devices.length > 0, deviceCount: devices.length };
+}
 
 /**
  * Enumerate AVFoundation video devices and return the index of the screen capture device
@@ -18,29 +70,15 @@ async function getScreenCaptureDeviceIndex(ffmpegPath: string, displayIndex: num
   if (cachedDeviceIndices.has(displayIndex)) {
     return cachedDeviceIndices.get(displayIndex)!;
   }
-
-  return new Promise((resolve) => {
-    execFile(
-      ffmpegPath,
-      ['-f', 'avfoundation', '-list_devices', 'true', '-i', ''],
-      (_err, _stdout, stderr) => {
-        const matched: string[] = [];
-        stderr.replace(/\[(\d+)\]\s+Capture\s+screen/gi, (_all, index: string) => {
-          matched.push(index);
-          return '';
-        });
-        if (matched.length === 0) {
-          console.warn('gEcho: No AVFoundation screen capture devices found; falling back to device 1');
-          cachedDeviceIndices.set(displayIndex, '1');
-          resolve('1');
-          return;
-        }
-        const device = matched[displayIndex] ?? matched[0];
-        cachedDeviceIndices.set(displayIndex, device);
-        resolve(device);
-      }
-    );
-  });
+  const matched = await enumerateAvfDevices(ffmpegPath);
+  if (matched.length === 0) {
+    console.warn('gEcho: No AVFoundation screen capture devices found; falling back to device 1');
+    cachedDeviceIndices.set(displayIndex, '1');
+    return '1';
+  }
+  const device = matched[displayIndex] ?? matched[0];
+  cachedDeviceIndices.set(displayIndex, device);
+  return device;
 }
 
 export class ScreenCapture {
@@ -68,6 +106,13 @@ export class ScreenCapture {
     let args: string[];
 
     if (platform === 'darwin') {
+      const perm = await checkScreenRecordingPermission(safeFfmpegPath);
+      if (!perm.granted) {
+        throw new Error(
+          'Screen Recording permission not granted. ' +
+          'Open System Settings → Privacy & Security → Screen Recording and enable VS Code, then restart VS Code.'
+        );
+      }
       // AVFoundation requires the input framerate to exactly match a supported device mode.
       // We capture at the native rate and downsample to the desired fps via the fps filter.
       const AVFOUNDATION_NATIVE_FRAMERATE = 60;

--- a/src/screen/index.ts
+++ b/src/screen/index.ts
@@ -1,1 +1,1 @@
-export { ScreenCapture } from './capture.js';
+export { ScreenCapture, checkScreenRecordingPermission } from './capture.js';


### PR DESCRIPTION
## Problem

On macOS, if VS Code has not been granted Screen Recording permission, AVFoundation lists no `Capture screen` devices. Previously, ffmpeg would fail silently or with a cryptic error after `ScreenCapture.start()` resolved.

## Solution

### `src/screen/capture.ts`
- **Extracted `enumerateAvfDevices(ffmpegPath)`** — runs `ffmpeg -list_devices` once and caches the result. Both the permission check and the device index lookup share this enumeration (ffmpeg is invoked at most once).
- **Added `checkScreenRecordingPermission(ffmpegPath?)`** — returns `{ granted: boolean; deviceCount: number }`. On non-darwin always returns `granted: true`.
- **`ScreenCapture.start()`** — calls `checkScreenRecordingPermission` at the top of the darwin branch and throws a descriptive, actionable error if permission is denied (before any capture is attempted).

### `src/screen/index.ts`
- Re-exports `checkScreenRecordingPermission` so callers outside the module can use it.

### `src/extension.ts`
- On extension activation (darwin only), calls `checkScreenRecordingPermission()` in the background. If denied, shows `showErrorMessage` with an **'Open System Settings'** button that deep-links directly to `Privacy & Security → Screen Recording`.

## Error message (thrown in `start()`)
```
Screen Recording permission not granted. Open System Settings → Privacy & Security → Screen Recording and enable VS Code, then restart VS Code.
```

## Checklist
- [x] `npm run compile` exits 0
- [x] No new external dependencies
- [x] ffmpeg enumeration runs only once (cached)
- [x] darwin-only logic; other platforms unaffected