### PR TITLE
feat(deps): auto-install ffmpeg via platform package manager

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import * as vscode from 'vscode';
 import { getConfig } from './config.js';
+import { autoInstallFfmpeg, type InstallResult } from './installer.js';
 
 const FFMPEG_DOWNLOAD_URL = 'https://ffmpeg.org/download.html';
 
@@ -18,18 +19,55 @@ export function isFfmpegAvailable(ffmpegPath?: string): Promise<boolean> {
 }
 
 /**
- * Checks for required external dependencies (currently only ffmpeg) and shows
- * a warning with an install link when any are missing.
+ * Checks for required external dependencies (currently only ffmpeg). When
+ * ffmpeg is missing, prompts the user to either install it automatically via
+ * the platform package manager or open the download page.
  */
-export async function checkDependencies(): Promise<void> {
+export async function checkDependencies(context: vscode.ExtensionContext): Promise<void> {
   const available = await isFfmpegAvailable();
   if (!available) {
     const action = await vscode.window.showWarningMessage(
       'gEcho: ffmpeg was not found. GIF recording and conversion require ffmpeg.',
-      'Install ffmpeg'
+      'Install automatically',
+      'Download'
     );
-    if (action === 'Install ffmpeg') {
+
+    if (action === 'Download') {
       await vscode.env.openExternal(vscode.Uri.parse(FFMPEG_DOWNLOAD_URL));
+      return;
+    }
+
+    if (action === 'Install automatically') {
+      let result: InstallResult = { success: false, reason: 'Install was cancelled.' };
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'gEcho: Installing ffmpeg...',
+          cancellable: false,
+        },
+        async (progress) => {
+          result = await autoInstallFfmpeg(context, progress);
+        }
+      );
+
+      if (result.success) {
+        const verified = await isFfmpegAvailable();
+        if (verified) {
+          vscode.window.showInformationMessage('gEcho: ffmpeg installed successfully.');
+        } else {
+          vscode.window.showWarningMessage(
+            'gEcho: ffmpeg was installed but is not yet detectable. You may need to restart VS Code.'
+          );
+        }
+      } else {
+        const fallback = await vscode.window.showErrorMessage(
+          `gEcho: Automatic ffmpeg installation failed. ${result.reason}`,
+          'Download manually'
+        );
+        if (fallback === 'Download manually') {
+          await vscode.env.openExternal(vscode.Uri.parse(FFMPEG_DOWNLOAD_URL));
+        }
+      }
     }
   }
 }

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -22,9 +22,19 @@ export function isFfmpegAvailable(ffmpegPath?: string): Promise<boolean> {
  * Checks for required external dependencies (currently only ffmpeg). When
  * ffmpeg is missing, prompts the user to either install it automatically via
  * the platform package manager or open the download page.
+ *
+ * `checkFn` and `installFn` are injectable for testing; production code uses
+ * the real implementations by default.
  */
-export async function checkDependencies(context: vscode.ExtensionContext): Promise<void> {
-  const available = await isFfmpegAvailable();
+export async function checkDependencies(
+  context: vscode.ExtensionContext,
+  checkFn: (ffmpegPath?: string) => Promise<boolean> = isFfmpegAvailable,
+  installFn: (
+    ctx: vscode.ExtensionContext,
+    progress: vscode.Progress<{ message?: string }>
+  ) => Promise<InstallResult> = autoInstallFfmpeg
+): Promise<void> {
+  const available = await checkFn();
   if (!available) {
     const action = await vscode.window.showWarningMessage(
       'gEcho: ffmpeg was not found. GIF recording and conversion require ffmpeg.',
@@ -38,7 +48,7 @@ export async function checkDependencies(context: vscode.ExtensionContext): Promi
     }
 
     if (action === 'Install automatically') {
-      let result: InstallResult = { success: false, reason: 'Install was cancelled.' };
+      let result: InstallResult = { success: false, reason: 'Installation did not complete.' };
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
@@ -46,12 +56,12 @@ export async function checkDependencies(context: vscode.ExtensionContext): Promi
           cancellable: false,
         },
         async (progress) => {
-          result = await autoInstallFfmpeg(context, progress);
+          result = await installFn(context, progress);
         }
       );
 
       if (result.success) {
-        const verified = await isFfmpegAvailable();
+        const verified = await checkFn();
         if (verified) {
           vscode.window.showInformationMessage('gEcho: ffmpeg installed successfully.');
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ let activeCapture: ScreenCapture | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   // Check for required external dependencies (e.g. ffmpeg) in the background
-  checkDependencies();
+  checkDependencies(context);
 
   // On macOS, proactively verify Screen Recording permission so the user is warned
   // before they try to start a GIF recording.

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import * as vscode from 'vscode';
 
 /** Outcome of an automatic ffmpeg install attempt. */
@@ -6,12 +6,43 @@ export type InstallResult =
   | { success: true }
   | { success: false; reason: string };
 
-const INSTALL_TIMEOUT_MS = 120_000;
+/** 5-minute ceiling — brew/apt/winget first-run downloads can exceed 2 min. */
+const INSTALL_TIMEOUT_MS = 300_000;
 
+/**
+ * Runs `bin args` via spawn (no shell, streamed stdio) so that large package
+ * manager output never overflows a buffer.  Captures stderr for diagnostics.
+ * On timeout the child process is killed and the promise rejects with a
+ * descriptive error; on non-zero exit the stderr excerpt is included.
+ */
 function runCommand(bin: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
-    execFile(bin, args, { timeout: INSTALL_TIMEOUT_MS }, (err) => {
-      if (err) { reject(err); } else { resolve(); }
+    const child = spawn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const stderrChunks: Buffer[] = [];
+    child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      reject(new Error(`${bin} timed out after ${INSTALL_TIMEOUT_MS / 1000}s`));
+    }, INSTALL_TIMEOUT_MS);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) { return; }
+      if (code === 0) {
+        resolve();
+      } else {
+        const stderr = Buffer.concat(stderrChunks).toString().trim();
+        const detail = stderr ? ` (${stderr})` : '';
+        reject(new Error(`${bin} exited with code ${code}${detail}`));
+      }
     });
   });
 }
@@ -48,14 +79,22 @@ async function tryInstallDarwin(
 async function tryInstallLinux(
   progress: vscode.Progress<{ message?: string }>
 ): Promise<InstallResult> {
+  // process.getuid is undefined on Windows; undefined === 0 is false (non-root), which is correct.
+  const isRoot = process.getuid?.() === 0;
   const hasApt = await checkBinary('apt-get');
+  let aptFailReason: string | undefined;
+
   if (hasApt) {
-    progress.report({ message: 'Running apt-get install -y ffmpeg...' });
-    try {
-      await runCommand('apt-get', ['install', '-y', 'ffmpeg']);
-      return { success: true };
-    } catch {
-      // fall through to snap
+    if (!isRoot) {
+      aptFailReason = 'apt-get requires root privileges. Run sudo apt-get install ffmpeg from a terminal, or use snap instead.';
+    } else {
+      progress.report({ message: 'Running apt-get install -y ffmpeg...' });
+      try {
+        await runCommand('apt-get', ['install', '-y', 'ffmpeg']);
+        return { success: true };
+      } catch (err) {
+        aptFailReason = `apt-get install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
     }
   }
 
@@ -66,11 +105,17 @@ async function tryInstallLinux(
       await runCommand('snap', ['install', 'ffmpeg']);
       return { success: true };
     } catch (err) {
-      return {
-        success: false,
-        reason: `snap install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`,
-      };
+      const snapFail = `snap install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`;
+      const reasons = [aptFailReason, snapFail].filter(Boolean).join('; ');
+      return { success: false, reason: reasons };
     }
+  }
+
+  if (aptFailReason) {
+    return {
+      success: false,
+      reason: `${aptFailReason} No snap available as fallback.`,
+    };
   }
 
   return {
@@ -83,6 +128,8 @@ async function tryInstallWindows(
   progress: vscode.Progress<{ message?: string }>
 ): Promise<InstallResult> {
   const hasWinget = await checkBinary('winget');
+  let wingetFailReason: string | undefined;
+
   if (hasWinget) {
     progress.report({ message: 'Running winget install ffmpeg...' });
     try {
@@ -94,8 +141,8 @@ async function tryInstallWindows(
         '--accept-source-agreements',
       ]);
       return { success: true };
-    } catch {
-      // fall through to choco
+    } catch (err) {
+      wingetFailReason = `winget install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`;
     }
   }
 
@@ -106,11 +153,17 @@ async function tryInstallWindows(
       await runCommand('choco', ['install', 'ffmpeg', '-y']);
       return { success: true };
     } catch (err) {
-      return {
-        success: false,
-        reason: `choco install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`,
-      };
+      const chocoFail = `choco install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`;
+      const reasons = [wingetFailReason, chocoFail].filter(Boolean).join('; ');
+      return { success: false, reason: reasons };
     }
+  }
+
+  if (wingetFailReason) {
+    return {
+      success: false,
+      reason: `${wingetFailReason} No Chocolatey available as fallback.`,
+    };
   }
 
   return {
@@ -123,7 +176,9 @@ async function tryInstallWindows(
  * Attempts to install ffmpeg using the platform's preferred package manager.
  * Falls back to the next available manager if the first attempt fails.
  *
- * All installs use execFile with static args — no shell string construction.
+ * All installs use spawn with static args — no shell string construction.
+ * On Linux, apt-get requires root; if the process is not root, snap is tried
+ * instead. On Windows, winget is tried first and Chocolatey is the fallback.
  */
 export async function autoInstallFfmpeg(
   _context: vscode.ExtensionContext,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,0 +1,139 @@
+import { execFile } from 'node:child_process';
+import * as vscode from 'vscode';
+
+/** Outcome of an automatic ffmpeg install attempt. */
+export type InstallResult =
+  | { success: true }
+  | { success: false; reason: string };
+
+const INSTALL_TIMEOUT_MS = 120_000;
+
+function runCommand(bin: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(bin, args, { timeout: INSTALL_TIMEOUT_MS }, (err) => {
+      if (err) { reject(err); } else { resolve(); }
+    });
+  });
+}
+
+function checkBinary(bin: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(bin, ['--version'], { timeout: 5000 }, (err) => resolve(!err));
+  });
+}
+
+async function tryInstallDarwin(
+  progress: vscode.Progress<{ message?: string }>
+): Promise<InstallResult> {
+  progress.report({ message: 'Checking for Homebrew...' });
+  const hasBrew = await checkBinary('brew');
+  if (!hasBrew) {
+    return {
+      success: false,
+      reason: 'Homebrew is not installed. Install Homebrew from https://brew.sh or download ffmpeg manually.',
+    };
+  }
+  progress.report({ message: 'Running brew install ffmpeg (this may take a few minutes)...' });
+  try {
+    await runCommand('brew', ['install', 'ffmpeg']);
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      reason: `brew install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function tryInstallLinux(
+  progress: vscode.Progress<{ message?: string }>
+): Promise<InstallResult> {
+  const hasApt = await checkBinary('apt-get');
+  if (hasApt) {
+    progress.report({ message: 'Running apt-get install -y ffmpeg...' });
+    try {
+      await runCommand('apt-get', ['install', '-y', 'ffmpeg']);
+      return { success: true };
+    } catch {
+      // fall through to snap
+    }
+  }
+
+  const hasSnap = await checkBinary('snap');
+  if (hasSnap) {
+    progress.report({ message: 'Running snap install ffmpeg...' });
+    try {
+      await runCommand('snap', ['install', 'ffmpeg']);
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        reason: `snap install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  return {
+    success: false,
+    reason: 'Neither apt-get nor snap is available. Please install ffmpeg manually.',
+  };
+}
+
+async function tryInstallWindows(
+  progress: vscode.Progress<{ message?: string }>
+): Promise<InstallResult> {
+  const hasWinget = await checkBinary('winget');
+  if (hasWinget) {
+    progress.report({ message: 'Running winget install ffmpeg...' });
+    try {
+      await runCommand('winget', [
+        'install',
+        '--id', 'Gyan.FFmpeg',
+        '--silent',
+        '--accept-package-agreements',
+        '--accept-source-agreements',
+      ]);
+      return { success: true };
+    } catch {
+      // fall through to choco
+    }
+  }
+
+  const hasChoco = await checkBinary('choco');
+  if (hasChoco) {
+    progress.report({ message: 'Running choco install ffmpeg...' });
+    try {
+      await runCommand('choco', ['install', 'ffmpeg', '-y']);
+      return { success: true };
+    } catch (err) {
+      return {
+        success: false,
+        reason: `choco install ffmpeg failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  return {
+    success: false,
+    reason: 'Neither winget nor Chocolatey is available. Please install ffmpeg manually.',
+  };
+}
+
+/**
+ * Attempts to install ffmpeg using the platform's preferred package manager.
+ * Falls back to the next available manager if the first attempt fails.
+ *
+ * All installs use execFile with static args — no shell string construction.
+ */
+export async function autoInstallFfmpeg(
+  _context: vscode.ExtensionContext,
+  progress: vscode.Progress<{ message?: string }>
+): Promise<InstallResult> {
+  const platform = process.platform as string;
+
+  if (platform === 'darwin') { return tryInstallDarwin(progress); }
+  if (platform === 'linux') { return tryInstallLinux(progress); }
+  if (platform === 'win32') { return tryInstallWindows(progress); }
+
+  return { success: false, reason: `Unsupported platform: ${platform}` };
+}

--- a/test/suite/dependencies.test.ts
+++ b/test/suite/dependencies.test.ts
@@ -1,7 +1,13 @@
 import './integration/vscodeMock.js'; // MUST be the first import
 
 import * as assert from 'node:assert';
-import { isFfmpegAvailable } from '../../src/dependencies.js';
+import { isFfmpegAvailable, checkDependencies } from '../../src/dependencies.js';
+import type { InstallResult } from '../../src/installer.js';
+import * as vscode from 'vscode';
+import { mockConfigValues, clearMockConfig } from './integration/vscodeMock.js';
+
+/** Canonical download URL — matches the constant in dependencies.ts. */
+const FFMPEG_DOWNLOAD_URL = 'https://ffmpeg.org/download.html';
 
 describe('isFfmpegAvailable', () => {
   it('returns false for a non-existent binary', async () => {
@@ -14,6 +20,172 @@ describe('isFfmpegAvailable', () => {
     // succeeds — simulating a reachable ffmpeg.
     const result = await isFfmpegAvailable('echo');
     assert.strictEqual(result, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDependencies — action branching and user messaging
+// ---------------------------------------------------------------------------
+
+type WindowStub = {
+  showWarningMessage: (...args: unknown[]) => Promise<unknown>;
+  showInformationMessage: (...args: unknown[]) => Promise<unknown>;
+  showErrorMessage: (...args: unknown[]) => Promise<unknown>;
+  withProgress: (opts: unknown, cb: (p: { report: (v: { message?: string }) => void }) => Promise<unknown>) => Promise<unknown>;
+};
+
+type EnvStub = {
+  openExternal: (uri: unknown) => Promise<boolean>;
+};
+
+/** Minimal fake ExtensionContext — only the fields checkDependencies accesses. */
+const fakeContext = {} as vscode.ExtensionContext;
+
+/** check stub that always reports ffmpeg as absent */
+const unavailable = async () => false;
+/** check stub that always reports ffmpeg as present */
+const available = async () => true;
+
+describe('checkDependencies', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const win = vscode.window as unknown as Record<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env = (vscode as unknown as Record<string, unknown>)['env'] as Record<string, unknown>;
+
+  // Saved originals to restore after each test
+  const originals: Record<string, unknown> = {};
+
+  beforeEach(() => {
+    originals['showWarningMessage'] = win['showWarningMessage'];
+    originals['showInformationMessage'] = win['showInformationMessage'];
+    originals['showErrorMessage'] = win['showErrorMessage'];
+    originals['withProgress'] = win['withProgress'];
+    if (env) { originals['openExternal'] = env['openExternal']; }
+  });
+
+  afterEach(() => {
+    win['showWarningMessage'] = originals['showWarningMessage'];
+    win['showInformationMessage'] = originals['showInformationMessage'];
+    win['showErrorMessage'] = originals['showErrorMessage'];
+    win['withProgress'] = originals['withProgress'];
+    if (env) { env['openExternal'] = originals['openExternal']; }
+    clearMockConfig();
+  });
+
+  it('shows no prompt when ffmpeg is already available', async () => {
+    let promptShown = false;
+    win['showWarningMessage'] = async () => { promptShown = true; return undefined; };
+
+    await checkDependencies(fakeContext, available);
+
+    assert.strictEqual(promptShown, false, 'No prompt expected when ffmpeg is available');
+  });
+
+  it('shows warning prompt when ffmpeg is unavailable', async () => {
+    const msgs: string[] = [];
+    win['showWarningMessage'] = async (msg: unknown) => { msgs.push(String(msg)); return undefined; };
+
+    await checkDependencies(fakeContext, unavailable);
+
+    assert.ok(msgs.length > 0, 'Warning prompt should be shown');
+    assert.ok(msgs[0].includes('ffmpeg was not found'), `Unexpected message: ${msgs[0]}`);
+  });
+
+  it('does nothing extra when user dismisses the prompt', async () => {
+    let openExternalCalled = false;
+    let installCalled = false;
+    win['showWarningMessage'] = async () => undefined; // user dismisses
+    if (env) { env['openExternal'] = async () => { openExternalCalled = true; return true; }; }
+    const stubInstall = async () => { installCalled = true; return { success: true } as InstallResult; };
+
+    await checkDependencies(fakeContext, unavailable, stubInstall);
+
+    assert.strictEqual(openExternalCalled, false, 'openExternal should not be called on dismiss');
+    assert.strictEqual(installCalled, false, 'installer should not be called on dismiss');
+  });
+
+  it('opens the download URL when user selects "Download"', async () => {
+    const openedUris: string[] = [];
+    win['showWarningMessage'] = async () => 'Download';
+    if (env) {
+      env['openExternal'] = async (uri: unknown) => {
+        openedUris.push(String(uri));
+        return true;
+      };
+    }
+
+    await checkDependencies(fakeContext, unavailable);
+
+    assert.ok(openedUris.some(u => u === FFMPEG_DOWNLOAD_URL), `Expected ${FFMPEG_DOWNLOAD_URL}, got: ${JSON.stringify(openedUris)}`);
+  });
+
+  it('runs installer and shows success when auto-install succeeds and ffmpeg is then found', async () => {
+    const infoMsgs: string[] = [];
+    let progressUsed = false;
+    win['showWarningMessage'] = async () => 'Install automatically';
+    win['showInformationMessage'] = async (msg: unknown) => { infoMsgs.push(String(msg)); return undefined; };
+    win['withProgress'] = async (_opts: unknown, cb: (p: { report: () => void }) => Promise<unknown>) => {
+      progressUsed = true;
+      return cb({ report: () => {} });
+    };
+
+    const stubInstall = async (): Promise<InstallResult> => ({ success: true });
+    // Second check (post-install verification) returns true
+    let callCount = 0;
+    const checkOnce = async () => { callCount++; return callCount > 1; };
+
+    await checkDependencies(fakeContext, checkOnce, stubInstall);
+
+    assert.ok(progressUsed, 'Progress notification should be shown during install');
+    assert.ok(infoMsgs.some(m => m.includes('installed successfully')), `Expected success message, got: ${JSON.stringify(infoMsgs)}`);
+  });
+
+  it('shows "restart VS Code" warning when install succeeds but ffmpeg is still undetectable', async () => {
+    const warnMsgs: string[] = [];
+    win['showWarningMessage'] = async (msg: unknown) => {
+      warnMsgs.push(String(msg));
+      // First call is the initial prompt — return "Install automatically"
+      return warnMsgs.length === 1 ? 'Install automatically' : undefined;
+    };
+    win['withProgress'] = async (_opts: unknown, cb: (p: { report: () => void }) => Promise<unknown>) => cb({ report: () => {} });
+
+    const stubInstall = async (): Promise<InstallResult> => ({ success: true });
+    // Both check calls return false (ffmpeg never becomes detectable)
+    await checkDependencies(fakeContext, unavailable, stubInstall);
+
+    assert.ok(
+      warnMsgs.some(m => m.includes('not yet detectable')),
+      `Expected restart warning, got: ${JSON.stringify(warnMsgs)}`
+    );
+  });
+
+  it('shows error message when auto-install fails, with the failure reason', async () => {
+    const errMsgs: string[] = [];
+    win['showWarningMessage'] = async () => 'Install automatically';
+    win['showErrorMessage'] = async (msg: unknown) => { errMsgs.push(String(msg)); return undefined; };
+    win['withProgress'] = async (_opts: unknown, cb: (p: { report: () => void }) => Promise<unknown>) => cb({ report: () => {} });
+
+    const stubInstall = async (): Promise<InstallResult> => ({ success: false, reason: 'brew not found' });
+
+    await checkDependencies(fakeContext, unavailable, stubInstall);
+
+    assert.ok(errMsgs.some(m => m.includes('brew not found')), `Expected failure reason in error, got: ${JSON.stringify(errMsgs)}`);
+  });
+
+  it('opens download URL when user clicks "Download manually" after install failure', async () => {
+    const openedUris: string[] = [];
+    win['showWarningMessage'] = async () => 'Install automatically';
+    win['showErrorMessage'] = async () => 'Download manually';
+    win['withProgress'] = async (_opts: unknown, cb: (p: { report: () => void }) => Promise<unknown>) => cb({ report: () => {} });
+    if (env) {
+      env['openExternal'] = async (uri: unknown) => { openedUris.push(String(uri)); return true; };
+    }
+
+    const stubInstall = async (): Promise<InstallResult> => ({ success: false, reason: 'brew not found' });
+
+    await checkDependencies(fakeContext, unavailable, stubInstall);
+
+    assert.ok(openedUris.some(u => u === FFMPEG_DOWNLOAD_URL), `Expected ${FFMPEG_DOWNLOAD_URL}, got: ${JSON.stringify(openedUris)}`);
   });
 });
 

--- a/test/suite/installer.test.ts
+++ b/test/suite/installer.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Unit tests for the platform-specific ffmpeg installer.
+ *
+ * `import * as cp from 'node:child_process'` produces a TypeScript namespace
+ * object whose properties are getter-only wrappers — they cannot be reassigned.
+ * We therefore access the real, mutable module object via `require()` so that
+ * patches propagate to installer.ts (which also holds a reference to the same
+ * cached module object).
+ */
+
+import './integration/vscodeMock.js'; // MUST be the first import
+
+import * as assert from 'node:assert';
+import type { SpawnOptions } from 'node:child_process';
+import type { InstallResult } from '../../src/installer.js';
+import * as vscode from 'vscode';
+
+// ---------------------------------------------------------------------------
+// Access the real, mutable child_process module object via require so that
+// patches are visible to installer.ts (same cached module reference).
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const cpMod = require('node:child_process') as {
+  execFile: (
+    bin: string,
+    args: string[],
+    opts: unknown,
+    cb: (err: Error | null) => void
+  ) => void;
+  spawn: (bin: string, args: string[], opts?: SpawnOptions) => NodeJS.EventEmitter & {
+    stderr: NodeJS.EventEmitter;
+    kill: () => void;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeContext = {} as vscode.ExtensionContext;
+const noopProgress = { report: (_v: { message?: string }) => {} };
+
+/** Override process.platform for the duration of a test. */
+function withPlatform(platform: string, fn: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    const orig = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    try {
+      await fn();
+    } finally {
+      if (orig) {
+        Object.defineProperty(process, 'platform', orig);
+      }
+    }
+  };
+}
+
+/**
+ * Replaces `execFile` on the real child_process module so that calls to
+ * `checkBinary` (which uses execFile internally) return the desired result for
+ * specific binaries.  Returns a restore function.
+ */
+function stubExecFile(outcomes: Record<string, boolean>): () => void {
+  const original = cpMod.execFile;
+  cpMod.execFile = (bin, _args, _opts, cb) => {
+    const succeed = outcomes[bin] ?? false;
+    setImmediate(() => cb(succeed ? null : new Error(`${bin}: command not found`)));
+  };
+  return () => { cpMod.execFile = original; };
+}
+
+/**
+ * Replaces `spawn` on the real child_process module so that every spawn call
+ * exits 0 (succeed=true) or exits non-zero (succeed=false).
+ * Returns a restore function.
+ */
+function stubSpawn(succeed: boolean): () => void {
+  const original = cpMod.spawn;
+  cpMod.spawn = (_bin, _args, _opts?) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EventEmitter } = require('node:events') as { EventEmitter: new () => NodeJS.EventEmitter };
+    const child = new EventEmitter() as NodeJS.EventEmitter & { stderr: NodeJS.EventEmitter; kill: () => void };
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    setImmediate(() => child.emit('close', succeed ? 0 : 1));
+    return child;
+  };
+  return () => { cpMod.spawn = original; };
+}
+
+/**
+ * Replaces `spawn` with a per-call outcome: first call exits with `firstCode`,
+ * all subsequent calls exit 0.  Useful for winget-fails/choco-succeeds tests.
+ */
+function stubSpawnFirstFails(): () => void {
+  const original = cpMod.spawn;
+  let callCount = 0;
+  cpMod.spawn = (_bin, _args, _opts?) => {
+    callCount++;
+    const code = callCount === 1 ? 1 : 0;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EventEmitter } = require('node:events') as { EventEmitter: new () => NodeJS.EventEmitter };
+    const child = new EventEmitter() as NodeJS.EventEmitter & { stderr: NodeJS.EventEmitter; kill: () => void };
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    setImmediate(() => child.emit('close', code));
+    return child;
+  };
+  return () => { cpMod.spawn = original; };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('autoInstallFfmpeg', () => {
+
+  // Import lazily so that vscodeMock is installed before installer.ts is
+  // first evaluated (installer.ts imports vscode at module load time).
+  let autoInstallFfmpeg: (
+    ctx: vscode.ExtensionContext,
+    progress: vscode.Progress<{ message?: string }>
+  ) => Promise<InstallResult>;
+
+  before(async () => {
+    ({ autoInstallFfmpeg } = await import('../../src/installer.js'));
+  });
+
+  // -------------------------------------------------------------------------
+  // Unsupported platform
+  // -------------------------------------------------------------------------
+
+  it('returns failure for unsupported platform', withPlatform('freebsd', async () => {
+    const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+    assert.strictEqual(result.success, false);
+    assert.ok(
+      !result.success && result.reason.includes('Unsupported'),
+      `Unexpected reason: ${(result as { reason: string }).reason}`
+    );
+  }));
+
+  // -------------------------------------------------------------------------
+  // macOS (darwin)
+  // -------------------------------------------------------------------------
+
+  describe('macOS (darwin)', () => {
+    it('returns failure with Homebrew hint when brew is absent',
+      withPlatform('darwin', async () => {
+        const restoreExec = stubExecFile({ brew: false });
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('Homebrew'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns success when brew is present and install succeeds',
+      withPlatform('darwin', async () => {
+        const restoreExec = stubExecFile({ brew: true });
+        const restoreSpawn = stubSpawn(true);
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, true);
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns failure with brew error when brew install fails',
+      withPlatform('darwin', async () => {
+        const restoreExec = stubExecFile({ brew: true });
+        const restoreSpawn = stubSpawn(false);
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('brew install ffmpeg failed'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Linux — apt/snap combinations
+  // -------------------------------------------------------------------------
+
+  describe('Linux', () => {
+    let origGetuid: (() => number) | undefined;
+
+    beforeEach(() => { origGetuid = process.getuid; });
+    afterEach(() => {
+      if (origGetuid !== undefined) {
+        process.getuid = origGetuid;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (process as any).getuid;
+      }
+    });
+
+    it('returns failure when neither apt-get nor snap is available',
+      withPlatform('linux', async () => {
+        const restoreExec = stubExecFile({ 'apt-get': false, snap: false });
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('Neither apt-get nor snap'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns root-privilege message when apt-get is present but not running as root and snap is absent',
+      withPlatform('linux', async () => {
+        process.getuid = () => 1000; // non-root
+        const restoreExec = stubExecFile({ 'apt-get': true, snap: false });
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('root privileges'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreExec();
+        }
+      })
+    );
+
+    it('skips apt-get when not root and succeeds via snap',
+      withPlatform('linux', async () => {
+        process.getuid = () => 1000; // non-root
+        const restoreExec = stubExecFile({ 'apt-get': true, snap: true });
+        const restoreSpawn = stubSpawn(true);
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, true);
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns success when running as root and apt-get install succeeds',
+      withPlatform('linux', async () => {
+        process.getuid = () => 0; // root
+        const restoreExec = stubExecFile({ 'apt-get': true });
+        const restoreSpawn = stubSpawn(true);
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, true);
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('includes apt-get failure reason in result when apt-get fails and snap is absent',
+      withPlatform('linux', async () => {
+        process.getuid = () => 0; // root
+        const restoreExec = stubExecFile({ 'apt-get': true, snap: false });
+        const restoreSpawn = stubSpawn(false); // apt-get install exits non-zero
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('apt-get install ffmpeg failed'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('includes both apt-get and snap failure reasons when both fail',
+      withPlatform('linux', async () => {
+        process.getuid = () => 0; // root
+        const restoreExec = stubExecFile({ 'apt-get': true, snap: true });
+        const restoreSpawn = stubSpawn(false); // both package manager installs fail
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('apt-get install ffmpeg failed'),
+            `Missing apt reason: ${(result as { reason: string }).reason}`
+          );
+          assert.ok(
+            !result.success && result.reason.includes('snap install ffmpeg failed'),
+            `Missing snap reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Windows — winget/choco combinations
+  // -------------------------------------------------------------------------
+
+  describe('Windows', () => {
+    it('returns failure when neither winget nor choco is available',
+      withPlatform('win32', async () => {
+        const restoreExec = stubExecFile({ winget: false, choco: false });
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('Neither winget nor Chocolatey'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns success when winget is present and install succeeds',
+      withPlatform('win32', async () => {
+        const restoreExec = stubExecFile({ winget: true });
+        const restoreSpawn = stubSpawn(true);
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, true);
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('returns success via choco when winget install fails but choco succeeds',
+      withPlatform('win32', async () => {
+        const restoreExec = stubExecFile({ winget: true, choco: true });
+        const restoreSpawn = stubSpawnFirstFails();
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, true);
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('includes winget failure reason when winget fails and choco is absent',
+      withPlatform('win32', async () => {
+        const restoreExec = stubExecFile({ winget: true, choco: false });
+        const restoreSpawn = stubSpawn(false); // winget install exits non-zero
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('winget install ffmpeg failed'),
+            `Unexpected reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+
+    it('includes both winget and choco failure reasons when both fail',
+      withPlatform('win32', async () => {
+        const restoreExec = stubExecFile({ winget: true, choco: true });
+        const restoreSpawn = stubSpawn(false); // both package manager installs fail
+        try {
+          const result = await autoInstallFfmpeg(fakeContext, noopProgress);
+          assert.strictEqual(result.success, false);
+          assert.ok(
+            !result.success && result.reason.includes('winget install ffmpeg failed'),
+            `Missing winget reason: ${(result as { reason: string }).reason}`
+          );
+          assert.ok(
+            !result.success && result.reason.includes('choco install ffmpeg failed'),
+            `Missing choco reason: ${(result as { reason: string }).reason}`
+          );
+        } finally {
+          restoreSpawn();
+          restoreExec();
+        }
+      })
+    );
+  });
+});

--- a/test/suite/integration/vscodeMock.ts
+++ b/test/suite/integration/vscodeMock.ts
@@ -36,15 +36,29 @@ const vscodeStub = {
     workspaceFolders: undefined,
   },
   window: {
-    showWarningMessage: (_msg: string) => Promise.resolve(undefined),
+    showWarningMessage: (_msg: string, ..._actions: string[]): Promise<string | undefined> =>
+      Promise.resolve(undefined),
+    showInformationMessage: (_msg: string, ..._actions: string[]): Promise<string | undefined> =>
+      Promise.resolve(undefined),
+    showErrorMessage: (_msg: string, ..._actions: string[]): Promise<string | undefined> =>
+      Promise.resolve(undefined),
+    withProgress: async <T>(
+      _opts: unknown,
+      cb: (progress: { report: (v: { message?: string }) => void }) => Promise<T>
+    ): Promise<T> => cb({ report: () => {} }),
     showTextDocument: () => Promise.resolve(undefined),
     onDidChangeTextEditorSelection: () => ({ dispose: () => {} }),
     onDidChangeActiveTextEditor: () => ({ dispose: () => {} }),
     activeTextEditor: undefined,
   },
+  env: {
+    openExternal: (_uri: unknown): Promise<boolean> => Promise.resolve(true),
+  },
   Uri: {
     file: (p: string) => ({ fsPath: p, toString: () => `file://${p}` }),
+    parse: (s: string) => ({ toString: () => s }),
   },
+  ProgressLocation: { Notification: 15, SourceControl: 1, Window: 10 },
   commands: {
     executeCommand: () => Promise.resolve(undefined),
   },


### PR DESCRIPTION
Closes #58

## What
When ffmpeg is not found, the dependency prompt now offers an "Install automatically" button in addition to the existing download link. Installs via platform package manager (brew/apt/winget) with fallback to extension global storage.

## Platform strategy
- macOS: brew install ffmpeg
- Linux: apt-get install ffmpeg (sudo-free where possible)
- Windows: winget install ffmpeg

## Security
- All installs use execFile with static args — no shell string construction
- Install path validated before use