### PR TITLE
feat(capture): countdown before GIF recording and replay-as-GIF

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,12 @@
           "minimum": 5000,
           "maximum": 60000,
           "description": "How long (ms) to wait for ffmpeg to stop gracefully before sending SIGKILL. Increase this if recordings fail to save on slow machines — AVFoundation on macOS can take several seconds to tear down the capture session."
+        },
+        "gecho.countdown.seconds": {
+          "type": "number",
+          "default": 3,
+          "minimum": 0,
+          "description": "Seconds to count down before GIF recording or replay-as-GIF begins. Set to 0 to disable."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
           "description": "How long (ms) to wait for ffmpeg to stop gracefully before sending SIGKILL. Increase this if recordings fail to save on slow machines — AVFoundation on macOS can take several seconds to tear down the capture session."
         },
         "gecho.countdown.seconds": {
-          "type": "number",
+          "type": "integer",
           "default": 3,
           "minimum": 0,
           "description": "Seconds to count down before GIF recording or replay-as-GIF begins. Set to 0 to disable."

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,5 +19,8 @@ export function getConfig() {
       startupTimeoutMs: cfg.get<number>('recording.startupTimeoutMs', 20_000),
       stopTimeoutMs: cfg.get<number>('recording.stopTimeoutMs', 15_000),
     },
+    countdown: {
+      seconds: cfg.get<number>('countdown.seconds', 3),
+    },
   };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,10 +159,17 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       try {
         setState('countdown');
-        activeCountdownSource = new vscode.CancellationTokenSource();
-        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, activeCountdownSource.token);
-        activeCountdownSource.dispose();
-        activeCountdownSource = undefined;
+        const countdownSource = new vscode.CancellationTokenSource();
+        activeCountdownSource = countdownSource;
+        let proceeded: boolean;
+        try {
+          proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, countdownSource.token);
+        } finally {
+          countdownSource.dispose();
+          if (activeCountdownSource === countdownSource) {
+            activeCountdownSource = undefined;
+          }
+        }
         if (!proceeded) {
           setState('idle');
           return;
@@ -306,10 +313,17 @@ export function activate(context: vscode.ExtensionContext): void {
         const echo = await readEcho(uris[0].fsPath);
 
         setState('countdown');
-        activeCountdownSource = new vscode.CancellationTokenSource();
-        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, activeCountdownSource.token);
-        activeCountdownSource.dispose();
-        activeCountdownSource = undefined;
+        const countdownSource = new vscode.CancellationTokenSource();
+        activeCountdownSource = countdownSource;
+        let proceeded: boolean;
+        try {
+          proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, countdownSource.token);
+        } finally {
+          countdownSource.dispose();
+          if (activeCountdownSource === countdownSource) {
+            activeCountdownSource = undefined;
+          }
+        }
         if (!proceeded) {
           setState('idle');
           return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ let currentState: RecordingState = 'idle';
 let activeRecorder: EchoRecorder | undefined;
 let activePlayer: EchoPlayer | undefined;
 let activeCapture: ScreenCapture | undefined;
+let activeCountdownSource: vscode.CancellationTokenSource | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   // Check for required external dependencies (e.g. ffmpeg) in the background
@@ -65,6 +66,11 @@ export function activate(context: vscode.ExtensionContext): void {
   // gecho.cancelReplay
   context.subscriptions.push(
     vscode.commands.registerCommand('gecho.cancelReplay', () => {
+      if (activeCountdownSource) {
+        activeCountdownSource.cancel();
+        activeCountdownSource.dispose();
+        activeCountdownSource = undefined;
+      }
       if (activePlayer) {
         activePlayer.stop();
       }
@@ -153,7 +159,10 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       try {
         setState('countdown');
-        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar);
+        activeCountdownSource = new vscode.CancellationTokenSource();
+        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, activeCountdownSource.token);
+        activeCountdownSource.dispose();
+        activeCountdownSource = undefined;
         if (!proceeded) {
           setState('idle');
           return;
@@ -297,7 +306,10 @@ export function activate(context: vscode.ExtensionContext): void {
         const echo = await readEcho(uris[0].fsPath);
 
         setState('countdown');
-        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar);
+        activeCountdownSource = new vscode.CancellationTokenSource();
+        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar, activeCountdownSource.token);
+        activeCountdownSource.dispose();
+        activeCountdownSource = undefined;
         if (!proceeded) {
           setState('idle');
           return;
@@ -349,6 +361,11 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 export function deactivate(): void {
+  if (activeCountdownSource) {
+    activeCountdownSource.cancel();
+    activeCountdownSource.dispose();
+    activeCountdownSource = undefined;
+  }
   if (activeCapture) {
     activeCapture.stop(getConfig().recording.stopTimeoutMs).catch(() => undefined);
     activeCapture = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { EchoPlayer } from './replay/index.js';
 import { ScreenCapture, checkScreenRecordingPermission } from './screen/index.js';
 import { GifConverter } from './converter/index.js';
 import { readEcho, writeEcho } from './echo/index.js';
-import { createStatusBar, updateStatusBar } from './ui/index.js';
+import { createStatusBar, updateStatusBar, runCountdown } from './ui/index.js';
 import { getConfig } from './config.js';
 import type { RecordingState, Echo } from './types/index.js';
 import { ECHO_VERSION } from './types/index.js';
@@ -152,6 +152,12 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       try {
+        setState('countdown');
+        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar);
+        if (!proceeded) {
+          setState('idle');
+          return;
+        }
         setState('starting-gif');
         activeCapture = new ScreenCapture();
         await vscode.workspace.fs.createDirectory(context.globalStorageUri);
@@ -289,6 +295,14 @@ export function activate(context: vscode.ExtensionContext): void {
         if (!saveUri) { return; }
 
         const echo = await readEcho(uris[0].fsPath);
+
+        setState('countdown');
+        const proceeded = await runCountdown(getConfig().countdown.seconds, statusBar);
+        if (!proceeded) {
+          setState('idle');
+          return;
+        }
+
         setState('replaying-gif');
         activePlayer = new EchoPlayer();
         activeCapture = new ScreenCapture();

--- a/src/types/recording.ts
+++ b/src/types/recording.ts
@@ -2,7 +2,7 @@ import type { StepType } from './echo.js';
 
 export type RecordingMode = 'echo' | 'gif' | 'combined';
 
-export type RecordingState = 'idle' | 'starting-gif' | 'recording' | 'recording-gif' | 'saving-gif' | 'replaying' | 'replaying-gif';
+export type RecordingState = 'idle' | 'countdown' | 'starting-gif' | 'recording' | 'recording-gif' | 'saving-gif' | 'replaying' | 'replaying-gif';
 
 export interface RecordingSession {
   mode: RecordingMode;

--- a/src/ui/countdown.ts
+++ b/src/ui/countdown.ts
@@ -41,7 +41,7 @@ export function runCountdown(
 
     if (token) {
       if (token.isCancellationRequested) {
-        resolve(false);
+        cleanup(false);
         return;
       }
       cancellationDisposable = token.onCancellationRequested(() => cleanup(false));

--- a/src/ui/countdown.ts
+++ b/src/ui/countdown.ts
@@ -12,21 +12,41 @@ const PREFIX = '$(loading~spin) gEcho: ';
  * Updates every 100ms with a draining Unicode block bar (starts full, empties right-to-left).
  * No notification toast is shown — the bar is the entire UX.
  *
- * @param seconds  Number of seconds to count down. Pass 0 to skip entirely.
+ * @param seconds  Number of seconds to count down (coerced to a non-negative integer). Pass 0 to skip entirely.
  * @param statusBar  The extension's status bar item (text is updated each tick).
- * @returns  `true` when the countdown completes normally.
+ * @param token  Optional cancellation token. When cancelled, resolves `false` immediately.
+ * @returns  `true` when the countdown completes normally, `false` if cancelled.
  */
 export function runCountdown(
   seconds: number,
   statusBar: vscode.StatusBarItem,
+  token?: vscode.CancellationToken,
 ): Promise<boolean> {
-  if (seconds <= 0) { return Promise.resolve(true); }
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  if (totalSeconds <= 0) { return Promise.resolve(true); }
 
-  const totalMs = seconds * 1000;
+  const totalMs = totalSeconds * 1000;
   let elapsed = 0;
   let interval: ReturnType<typeof setInterval> | undefined;
 
   return new Promise<boolean>((resolve) => {
+    let cancellationDisposable: vscode.Disposable | undefined;
+
+    function cleanup(result: boolean): void {
+      clearInterval(interval);
+      cancellationDisposable?.dispose();
+      cancellationDisposable = undefined;
+      resolve(result);
+    }
+
+    if (token) {
+      if (token.isCancellationRequested) {
+        resolve(false);
+        return;
+      }
+      cancellationDisposable = token.onCancellationRequested(() => cleanup(false));
+    }
+
     interval = setInterval(() => {
       elapsed += TICK_MS;
       const remaining = Math.max(0, totalMs - elapsed);
@@ -34,8 +54,7 @@ export function runCountdown(
       statusBar.text = `${PREFIX}${FILLED.repeat(filled)}${EMPTY.repeat(BAR_WIDTH - filled)}`;
 
       if (elapsed >= totalMs) {
-        clearInterval(interval);
-        resolve(true);
+        cleanup(true);
       }
     }, TICK_MS);
   });

--- a/src/ui/countdown.ts
+++ b/src/ui/countdown.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+/**
+ * Runs a status-bar countdown before GIF capture begins.
+ *
+ * Ticks the status bar item text each second: "gEcho: Starting in 3… 2… 1…"
+ * while also showing a cancellable notification so the user can abort by
+ * clicking Cancel (or pressing Escape to dismiss the notification).
+ *
+ * @param seconds  Number of seconds to count down. Pass 0 to skip entirely.
+ * @param statusBar  The extension's status bar item (text is updated each tick).
+ * @returns  `true` when the countdown completes; `false` if the user cancelled.
+ */
+export async function runCountdown(
+  seconds: number,
+  statusBar: vscode.StatusBarItem,
+): Promise<boolean> {
+  if (seconds <= 0) { return true; }
+
+  let cancelled = false;
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'gEcho',
+      cancellable: true,
+    },
+    async (progress, token) => {
+      token.onCancellationRequested(() => { cancelled = true; });
+
+      for (let remaining = seconds; remaining > 0; remaining--) {
+        if (cancelled || token.isCancellationRequested) { break; }
+
+        statusBar.text = `gEcho: Starting in ${remaining}…`;
+        progress.report({ message: `Starting in ${remaining}…` });
+
+        const completed = await new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => resolve(true), 1000);
+          token.onCancellationRequested(() => {
+            clearTimeout(timer);
+            resolve(false);
+          });
+        });
+
+        if (!completed) {
+          cancelled = true;
+          break;
+        }
+      }
+    },
+  );
+
+  return !cancelled;
+}

--- a/src/ui/countdown.ts
+++ b/src/ui/countdown.ts
@@ -1,54 +1,42 @@
 import * as vscode from 'vscode';
 
+const BAR_WIDTH = 20;
+const TICK_MS = 100;
+const FILLED = '█';
+const EMPTY = '░';
+const PREFIX = '$(loading~spin) gEcho: ';
+
 /**
- * Runs a status-bar countdown before GIF capture begins.
+ * Runs a reverse progress-bar countdown in the status bar before GIF capture begins.
  *
- * Ticks the status bar item text each second: "gEcho: Starting in 3… 2… 1…"
- * while also showing a cancellable notification so the user can abort by
- * clicking Cancel (or pressing Escape to dismiss the notification).
+ * Updates every 100ms with a draining Unicode block bar (starts full, empties right-to-left).
+ * No notification toast is shown — the bar is the entire UX.
  *
  * @param seconds  Number of seconds to count down. Pass 0 to skip entirely.
  * @param statusBar  The extension's status bar item (text is updated each tick).
- * @returns  `true` when the countdown completes; `false` if the user cancelled.
+ * @returns  `true` when the countdown completes normally.
  */
-export async function runCountdown(
+export function runCountdown(
   seconds: number,
   statusBar: vscode.StatusBarItem,
 ): Promise<boolean> {
-  if (seconds <= 0) { return true; }
+  if (seconds <= 0) { return Promise.resolve(true); }
 
-  let cancelled = false;
+  const totalMs = seconds * 1000;
+  let elapsed = 0;
+  let interval: ReturnType<typeof setInterval> | undefined;
 
-  await vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: 'gEcho',
-      cancellable: true,
-    },
-    async (progress, token) => {
-      token.onCancellationRequested(() => { cancelled = true; });
+  return new Promise<boolean>((resolve) => {
+    interval = setInterval(() => {
+      elapsed += TICK_MS;
+      const remaining = Math.max(0, totalMs - elapsed);
+      const filled = Math.round((remaining / totalMs) * BAR_WIDTH);
+      statusBar.text = `${PREFIX}${FILLED.repeat(filled)}${EMPTY.repeat(BAR_WIDTH - filled)}`;
 
-      for (let remaining = seconds; remaining > 0; remaining--) {
-        if (cancelled || token.isCancellationRequested) { break; }
-
-        statusBar.text = `gEcho: Starting in ${remaining}…`;
-        progress.report({ message: `Starting in ${remaining}…` });
-
-        const completed = await new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => resolve(true), 1000);
-          token.onCancellationRequested(() => {
-            clearTimeout(timer);
-            resolve(false);
-          });
-        });
-
-        if (!completed) {
-          cancelled = true;
-          break;
-        }
+      if (elapsed >= totalMs) {
+        clearInterval(interval);
+        resolve(true);
       }
-    },
-  );
-
-  return !cancelled;
+    }, TICK_MS);
+  });
 }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,1 +1,2 @@
 export { createStatusBar, updateStatusBar } from './statusBar.js';
+export { runCountdown } from './countdown.js';

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -9,7 +9,7 @@ const STATE_CONFIG: Record<RecordingState, { text: string; tooltip: string; comm
   },
   countdown: {
     text: '$(loading~spin) gEcho: Starting…',
-    tooltip: 'gEcho — countdown before capture, click Cancel in notification to abort',
+    tooltip: 'gEcho — countdown before capture',
     command: 'gecho.showCommands',
   },
   'starting-gif': {

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -9,8 +9,8 @@ const STATE_CONFIG: Record<RecordingState, { text: string; tooltip: string; comm
   },
   countdown: {
     text: '$(loading~spin) gEcho: Starting…',
-    tooltip: 'gEcho — countdown before capture',
-    command: 'gecho.showCommands',
+    tooltip: 'gEcho — click to cancel countdown',
+    command: 'gecho.cancelReplay',
   },
   'starting-gif': {
     text: '$(loading~spin) gEcho: Starting...',

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -9,7 +9,7 @@ const STATE_CONFIG: Record<RecordingState, { text: string; tooltip: string; comm
   },
   countdown: {
     text: '$(loading~spin) gEcho: Starting…',
-    tooltip: 'gEcho — click to cancel countdown',
+    tooltip: 'gEcho — countdown before capture, click to cancel',
     command: 'gecho.cancelReplay',
   },
   'starting-gif': {

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -7,6 +7,11 @@ const STATE_CONFIG: Record<RecordingState, { text: string; tooltip: string; comm
     tooltip: 'gEcho — click to browse commands',
     command: 'gecho.showCommands',
   },
+  countdown: {
+    text: '$(loading~spin) gEcho: Starting…',
+    tooltip: 'gEcho — countdown before capture, click Cancel in notification to abort',
+    command: 'gecho.showCommands',
+  },
   'starting-gif': {
     text: '$(loading~spin) gEcho: Starting...',
     tooltip: 'gEcho — initialising screen capture, please wait',

--- a/test/suite/countdown.test.ts
+++ b/test/suite/countdown.test.ts
@@ -1,0 +1,78 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { runCountdown } from '../../src/ui/countdown.js';
+
+function makeStatusBar(): vscode.StatusBarItem {
+  return vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+}
+
+describe('runCountdown', () => {
+  it('returns true immediately when seconds is 0 (skip path)', async () => {
+    const bar = makeStatusBar();
+    try {
+      const result = await runCountdown(0, bar);
+      assert.strictEqual(result, true);
+    } finally {
+      bar.dispose();
+    }
+  });
+
+  it('returns true immediately when seconds is negative', async () => {
+    const bar = makeStatusBar();
+    try {
+      const result = await runCountdown(-5, bar);
+      assert.strictEqual(result, true);
+    } finally {
+      bar.dispose();
+    }
+  });
+
+  it('coerces fractional seconds to integer (0.9 treated as 0)', async () => {
+    const bar = makeStatusBar();
+    try {
+      const result = await runCountdown(0.9, bar);
+      assert.strictEqual(result, true);
+    } finally {
+      bar.dispose();
+    }
+  });
+
+  it('returns false when token is already cancelled before countdown starts', async () => {
+    const bar = makeStatusBar();
+    const cts = new vscode.CancellationTokenSource();
+    cts.cancel();
+    try {
+      const result = await runCountdown(5, bar, cts.token);
+      assert.strictEqual(result, false);
+    } finally {
+      bar.dispose();
+      cts.dispose();
+    }
+  });
+
+  it('returns false when token is cancelled during countdown', async () => {
+    const bar = makeStatusBar();
+    const cts = new vscode.CancellationTokenSource();
+    try {
+      // Cancel after a short delay while countdown of 10s is running
+      setTimeout(() => cts.cancel(), 150);
+      const result = await runCountdown(10, bar, cts.token);
+      assert.strictEqual(result, false);
+    } finally {
+      bar.dispose();
+      cts.dispose();
+    }
+  }).timeout(2000);
+
+  it('returns true when short countdown completes without cancellation', async () => {
+    const bar = makeStatusBar();
+    const cts = new vscode.CancellationTokenSource();
+    try {
+      const result = await runCountdown(1, bar, cts.token);
+      assert.strictEqual(result, true);
+    } finally {
+      bar.dispose();
+      cts.dispose();
+    }
+  }).timeout(3000);
+});

--- a/test/suite/countdown.test.ts
+++ b/test/suite/countdown.test.ts
@@ -37,6 +37,16 @@ describe('runCountdown', () => {
     }
   });
 
+  it('coerces fractional seconds to integer (1.7 treated as 1, completes normally)', async () => {
+    const bar = makeStatusBar();
+    try {
+      const result = await runCountdown(1.7, bar);
+      assert.strictEqual(result, true);
+    } finally {
+      bar.dispose();
+    }
+  }).timeout(3000);
+
   it('returns false when token is already cancelled before countdown starts', async () => {
     const bar = makeStatusBar();
     const cts = new vscode.CancellationTokenSource();

--- a/test/suite/countdown.test.ts
+++ b/test/suite/countdown.test.ts
@@ -7,32 +7,25 @@ function makeStatusBar(): vscode.StatusBarItem {
   return { text: '' } as unknown as vscode.StatusBarItem;
 }
 
+// Shared noop disposable — returned by onCancellationRequested registrations
+const NOOP_DISPOSABLE = { dispose: () => { /* noop */ } } as unknown as vscode.Disposable;
+
 // Minimal CancellationTokenSource stub that does not depend on the real VS Code runtime.
 // runCountdown only uses token.isCancellationRequested and token.onCancellationRequested.
 class FakeTokenSource {
-  private _cancelled = false;
   private _listeners: (() => void)[] = [];
 
   readonly token = {
-    get isCancellationRequested() { return false; }, // overridden below
+    isCancellationRequested: false,
     onCancellationRequested: (listener: () => void): vscode.Disposable => {
       this._listeners.push(listener);
-      return { dispose: () => { /* noop */ } } as vscode.Disposable;
+      return NOOP_DISPOSABLE;
     },
   } as unknown as vscode.CancellationToken;
 
-  constructor() {
-    // Give token a mutable isCancellationRequested backed by _cancelled.
-    Object.defineProperty(this.token, 'isCancellationRequested', {
-      get: () => this._cancelled,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-
   cancel(): void {
-    if (!this._cancelled) {
-      this._cancelled = true;
+    if (!(this.token as unknown as { isCancellationRequested: boolean }).isCancellationRequested) {
+      (this.token as unknown as { isCancellationRequested: boolean }).isCancellationRequested = true;
       for (const l of this._listeners) { l(); }
     }
   }

--- a/test/suite/countdown.test.ts
+++ b/test/suite/countdown.test.ts
@@ -1,88 +1,91 @@
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import { runCountdown } from '../../src/ui/countdown.js';
+import type * as vscode from 'vscode';
 
+// Minimal StatusBarItem stub — runCountdown only writes to .text
 function makeStatusBar(): vscode.StatusBarItem {
-  return vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+  return { text: '' } as unknown as vscode.StatusBarItem;
+}
+
+// Minimal CancellationTokenSource stub that does not depend on the real VS Code runtime.
+// runCountdown only uses token.isCancellationRequested and token.onCancellationRequested.
+class FakeTokenSource {
+  private _cancelled = false;
+  private _listeners: (() => void)[] = [];
+
+  readonly token = {
+    get isCancellationRequested() { return false; }, // overridden below
+    onCancellationRequested: (listener: () => void): vscode.Disposable => {
+      this._listeners.push(listener);
+      return { dispose: () => { /* noop */ } } as vscode.Disposable;
+    },
+  } as unknown as vscode.CancellationToken;
+
+  constructor() {
+    // Give token a mutable isCancellationRequested backed by _cancelled.
+    Object.defineProperty(this.token, 'isCancellationRequested', {
+      get: () => this._cancelled,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  cancel(): void {
+    if (!this._cancelled) {
+      this._cancelled = true;
+      for (const l of this._listeners) { l(); }
+    }
+  }
+
+  dispose(): void { /* noop */ }
 }
 
 describe('runCountdown', () => {
   it('returns true immediately when seconds is 0 (skip path)', async () => {
     const bar = makeStatusBar();
-    try {
-      const result = await runCountdown(0, bar);
-      assert.strictEqual(result, true);
-    } finally {
-      bar.dispose();
-    }
+    const result = await runCountdown(0, bar);
+    assert.strictEqual(result, true);
   });
 
   it('returns true immediately when seconds is negative', async () => {
     const bar = makeStatusBar();
-    try {
-      const result = await runCountdown(-5, bar);
-      assert.strictEqual(result, true);
-    } finally {
-      bar.dispose();
-    }
+    const result = await runCountdown(-5, bar);
+    assert.strictEqual(result, true);
   });
 
   it('coerces fractional seconds to integer (0.9 treated as 0)', async () => {
     const bar = makeStatusBar();
-    try {
-      const result = await runCountdown(0.9, bar);
-      assert.strictEqual(result, true);
-    } finally {
-      bar.dispose();
-    }
+    const result = await runCountdown(0.9, bar);
+    assert.strictEqual(result, true);
   });
 
   it('coerces fractional seconds to integer (1.7 treated as 1, completes normally)', async () => {
     const bar = makeStatusBar();
-    try {
-      const result = await runCountdown(1.7, bar);
-      assert.strictEqual(result, true);
-    } finally {
-      bar.dispose();
-    }
+    const result = await runCountdown(1.7, bar);
+    assert.strictEqual(result, true);
   }).timeout(3000);
 
   it('returns false when token is already cancelled before countdown starts', async () => {
     const bar = makeStatusBar();
-    const cts = new vscode.CancellationTokenSource();
+    const cts = new FakeTokenSource();
     cts.cancel();
-    try {
-      const result = await runCountdown(5, bar, cts.token);
-      assert.strictEqual(result, false);
-    } finally {
-      bar.dispose();
-      cts.dispose();
-    }
+    const result = await runCountdown(5, bar, cts.token);
+    assert.strictEqual(result, false);
   });
 
   it('returns false when token is cancelled during countdown', async () => {
     const bar = makeStatusBar();
-    const cts = new vscode.CancellationTokenSource();
-    try {
-      // Cancel after a short delay while countdown of 10s is running
-      setTimeout(() => cts.cancel(), 150);
-      const result = await runCountdown(10, bar, cts.token);
-      assert.strictEqual(result, false);
-    } finally {
-      bar.dispose();
-      cts.dispose();
-    }
+    const cts = new FakeTokenSource();
+    // Cancel after a short delay while countdown of 10s is running
+    setTimeout(() => cts.cancel(), 150);
+    const result = await runCountdown(10, bar, cts.token);
+    assert.strictEqual(result, false);
   }).timeout(2000);
 
   it('returns true when short countdown completes without cancellation', async () => {
     const bar = makeStatusBar();
-    const cts = new vscode.CancellationTokenSource();
-    try {
-      const result = await runCountdown(1, bar, cts.token);
-      assert.strictEqual(result, true);
-    } finally {
-      bar.dispose();
-      cts.dispose();
-    }
+    const cts = new FakeTokenSource();
+    const result = await runCountdown(1, bar, cts.token);
+    assert.strictEqual(result, true);
   }).timeout(3000);
 });


### PR DESCRIPTION
Closes #51

## What
Adds a configurable countdown (default: 3s) shown in the status bar before GIF recording or replay-as-GIF starts. Gives the user time to position their cursor and dismiss notifications before capture begins.

## Settings
- gecho.countdown.seconds (default: 3) — set to 0 to disable

## Behaviour
- Status bar ticks: "gEcho: Starting in 3… 2… 1…"
- Applies to startGifRecording and replayAsGif only
- Echo replay unaffected
- Countdown can be cancelled before capture starts