### PR TITLE
feat(replay): Add focus step type for explicit editor focus control

### DIFF
--- a/.tours/adding-a-step-type.tour
+++ b/.tours/adding-a-step-type.tour
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Adding a New Step Type",
+  "description": "A contributor guide for implementing a new echo step type. Uses the `focus` step (added in PR #88) as a worked example. Follow these steps in order — all 7 must be completed.",
+  "steps": [
+    {
+      "file": "src/types/echo.ts",
+      "line": 55,
+      "title": "Step 1 — Define the TypeScript interface",
+      "description": "Define your new step interface here, next to the existing ones.\n\nFor simple steps, a plain interface is enough:\n```typescript\nexport interface MyStep {\n  type: 'myStep';\n  // ...fields\n}\n```\n\nIf your step has a field with a constrained set of values, model it as a `const` tuple + type alias + type guard (see `FOCUS_TARGETS` / `FocusTarget` / `isFocusTarget` just above this line). This lets the runtime validator in `src/echo/echo.ts` reuse the same source of truth instead of duplicating the list of allowed values."
+    },
+    {
+      "file": "src/types/echo.ts",
+      "line": 60,
+      "title": "Step 2 — Add to the StepType union",
+      "description": "Add your new interface to the `StepType` discriminated union.\n\n```typescript\nexport type StepType =\n  | TypeStep\n  | ...\n  | MyStep;   // ← add here\n```\n\nTypeScript will now flag any exhaustive switch (like the one in the player) that is missing your new case. Fix those before moving on."
+    },
+    {
+      "file": "src/types/index.ts",
+      "line": 1,
+      "title": "Step 3 — Re-export from the types barrel",
+      "description": "Add your new type (and any companion constants/guards) to the re-export list in `src/types/index.ts`.\n\n- Interface types go in the `export type { ... }` block\n- Runtime values (const arrays, type guard functions) go in the `export { ... }` block\n\nThis ensures other modules can import from `'../types/index.js'` without reaching into `'../types/echo.js'` directly."
+    },
+    {
+      "file": "schemas/gecho-v1.schema.json",
+      "line": 280,
+      "title": "Step 4 — Add JSON Schema definition",
+      "description": "Add a `$defs` entry for your new step type and reference it in the `Step.oneOf` array (around line 73).\n\nFollow the existing pattern:\n```json\n\"MyStep\": {\n  \"type\": \"object\",\n  \"required\": [\"type\", \"myField\"],\n  \"additionalProperties\": false,\n  \"description\": \"What this step does\",\n  \"properties\": {\n    \"type\": { \"type\": \"string\", \"const\": \"myStep\" },\n    \"myField\": { ... }\n  }\n}\n```\n\nThen add `{ \"$ref\": \"#/$defs/MyStep\" }` to the `oneOf` list.\n\nBefore v1.0.0 release, no schema version bump or migration is needed. After release, additive changes (new optional step types) are still migration-free."
+    },
+    {
+      "file": "src/echo/echo.ts",
+      "line": 76,
+      "title": "Step 5 — Add to isValidStep()",
+      "description": "Add a `case` for your new step type in `isValidStep()`. This is the runtime guard that `readEcho()` uses — without it, any echo file containing your new step will throw `\"Invalid echo format\"`.\n\n```typescript\ncase 'myStep':\n  return typeof s['myField'] === 'string';\n```\n\nFor constrained fields (like `focus.target`), import and use your type guard instead of a raw string check:\n```typescript\ncase 'myStep':\n  return isMyFieldValue(s['myField']);\n```"
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 219,
+      "title": "Step 6 — Handle in EchoPlayer",
+      "description": "Add a `case` to the step `switch` in `EchoPlayer.play()`.\n\nKey rules:\n- If your step takes a user-supplied command ID, call `sanitizeCommandId()` first\n- If your step takes a user-supplied file path, call `sanitizeFilePath()` first\n- If your step takes a user-supplied ffmpeg path, call `sanitizeFfmpegPath()` first\n- The `FOCUS_COMMANDS` map above is a good pattern for steps that map a typed enum to VS Code commands: type it as `Record<MyTarget, string>` for compile-time exhaustiveness\n\nThe `default` case is intentionally a no-op (not an error), so older players skip unknown step types gracefully when replaying newer echo files."
+    },
+    {
+      "file": "docs/echo-reference.md",
+      "line": 43,
+      "title": "Step 7 — Document it",
+      "description": "Update `docs/echo-reference.md`:\n\n1. Increment the step type count in the intro paragraph (currently `9 step types`)\n2. Add a new `### \\`myStep\\` — Title` section following the existing pattern (JSON example, field table, Notes)\n3. Add your step to the example echo at the bottom of the file\n4. Add an authoring tip if relevant\n\nAlso check `echoes/example.echo.json` — if it demonstrates all step types, add yours there too."
+    }
+  ]
+}

--- a/.tours/architecture-overview.tour
+++ b/.tours/architecture-overview.tour
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Architecture Overview",
+  "description": "A guided walkthrough of gEcho's module structure and core concepts. Start here if you are new to the codebase.",
+  "steps": [
+    {
+      "file": "src/types/echo.ts",
+      "line": 60,
+      "title": "1. The Echo Format — StepType Union",
+      "description": "Every echo is a sequence of `StepType` steps. The union is a **discriminated union** on the `type` string literal — this is the central data contract of the whole extension.\n\nAll step types are defined in this file. When you add a new step type, this is your first stop. The `default` case in the player's switch statement must always handle unknown steps (exhaustiveness check).\n\nThe echo format itself is a `.echo.json` file: `{ version, metadata, steps[] }`. See `schemas/gecho-v1.schema.json` for the JSON Schema definition."
+    },
+    {
+      "file": "src/echo/echo.ts",
+      "line": 26,
+      "title": "2. Echo I/O — validateEcho",
+      "description": "`validateEcho()` is a runtime type guard that checks every field and step before trusting the data. It is called by `readEcho()` before returning an `Echo` to callers.\n\nThe `isValidStep()` function below it has a `switch` mirroring the `StepType` union — every new step type must be added to both.\n\nThis module has **no VS Code dependency** — it is pure Node.js `fs/promises` and is tested by plain Mocha without an Extension Host."
+    },
+    {
+      "file": "src/recording/recorder.ts",
+      "line": 7,
+      "title": "3. Recording — EchoRecorder",
+      "description": "`EchoRecorder` listens to three VS Code events and translates them into `StepType[]`:\n\n- `onDidChangeTextDocument` → `TypeStep` (with coalescing of adjacent single-char inserts)\n- `onDidChangeTextEditorSelection` → `SelectStep`\n- `onDidChangeActiveTextEditor` → `OpenFileStep`\n\nCall `start()` to begin recording, `stop()` to receive the collected steps. The recorder is **stateless between sessions** — `start()` resets everything.\n\nNote: The VS Code API does not expose mouse events or widget-level focus changes, so those cannot be recorded automatically."
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 38,
+      "title": "4. Replay — EchoPlayer",
+      "description": "`EchoPlayer` is the inverse of `EchoRecorder`. It takes a `StepType[]` and executes each step against the VS Code API.\n\nKey behaviours:\n- **`cancelOnInput`**: if a real user types or clicks while replay is running, it stops. Implemented by watching `onDidChangeTextDocument` and `onDidChangeTextEditorSelection`.\n- **`speed`**: all delay values are divided by this multiplier.\n- **`isExecutingStep` flag**: guards the cancel listeners so they don't fire on the player's own programmatic changes."
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 97,
+      "title": "5. Step Dispatch — The Switch Statement",
+      "description": "The core of the player is this `switch` on `step.type`. Each case maps one `StepType` to VS Code API calls.\n\nArchitectural rules enforced here:\n- `sanitizeCommandId()` must be called before every `executeCommand` that takes a step-supplied ID\n- `sanitizeFilePath()` must be called before every file open that takes a step-supplied path\n- The `default` case is the exhaustiveness fallback — unknown step types are silently skipped so old players can replay newer echo files gracefully"
+    },
+    {
+      "file": "src/security/sanitizer.ts",
+      "line": 5,
+      "title": "6. Security — Sanitizers",
+      "description": "Three sanitizer functions guard all externally-supplied inputs:\n\n- **`sanitizeFilePath()`** — rejects path traversal (`../`), absolute paths outside the workspace\n- **`sanitizeCommandId()`** — allowlists command IDs to `[a-zA-Z0-9._-]+` only\n- **`sanitizeFfmpegPath()`** — validates the ffmpeg binary path\n\n**Architecture rule**: these must be called before every `executeCommand(step.id)`, every file open from an echo step, and every ffmpeg spawn. Skipping them is a security defect."
+    },
+    {
+      "file": "src/screen/capture.ts",
+      "line": 80,
+      "title": "7. Screen Capture — ScreenCapture",
+      "description": "`ScreenCapture` wraps ffmpeg for recording the VS Code window as a video file (later converted to GIF).\n\nPlatform-specific details:\n- **macOS**: AVFoundation device — index is dynamic, enumerated at runtime via `enumerateAvfDevices()` (cached as a Promise to avoid double-spawning)\n- **Linux**: x11grab\n- **Windows**: gdigrab\n\nThe class spawns ffmpeg as a child process. `stop()` sends SIGINT and waits for the process to exit cleanly.\n\n**All errors thrown from this file must begin with `'gEcho:'`** for consistency."
+    },
+    {
+      "file": "src/platform/platform.ts",
+      "line": 71,
+      "title": "8. Platform Layer — getWindowInfo",
+      "description": "`getWindowInfo()` resolves the VS Code window's pixel bounds and which display it is on. This is used by `ScreenCapture` to crop the ffmpeg input to just the VS Code window.\n\nIt spawns a platform-specific helper binary from `resources/bin/{platform}/gecho-helper*` (compiled separately — not a Node.js file). The result is **cached as a module-level Promise** so concurrent callers share one subprocess invocation.\n\nFallback: if the helper fails, bounds default to `{ x:0, y:0, width:1920, height:1080 }`."
+    },
+    {
+      "file": "src/config.ts",
+      "line": 4,
+      "title": "9. Configuration — getConfig",
+      "description": "`getConfig()` is the single access point for all `gecho.*` VS Code settings. Every feature reads configuration through here — no raw `vscode.workspace.getConfiguration()` calls scattered around the codebase.\n\nSettings are defined in `package.json` under `contributes.configuration`. The current settings cover: replay speed, cancelOnInput, output format, scale, crop, and startup/stop timeouts."
+    },
+    {
+      "file": "src/extension.ts",
+      "line": 75,
+      "title": "10. Entry Point — activate()",
+      "description": "`activate()` is the only entry point VS Code calls. It is intentionally thin: it registers commands, creates the status bar, and checks dependencies. All real logic lives in the modules above.\n\n**Activation policy**: gEcho activates only on `onCommand:gecho.*` — never on startup. Do not add `onStartupFinished` or `\"*\"` activation.\n\nThe module-level `currentState: RecordingState` and `active*` variables (recorder, player, capture) are the only global state. There is no separate state manager.\n\n`deactivate()` at the bottom of this file cleans up all three active objects."
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ Thank you for contributing! This document outlines our contribution and testing 
 
 The echo format lives in `schemas/gecho-v1.schema.json` and `src/types/echo.ts`.
 
-**Before the v1.0.0 extension release**, additive schema changes (new step types, new optional fields) do **not** require a version bump or migration function. The schema version string stays at `"1.0"` and existing echo files remain valid.
+**Before the v1.0.0 extension release**, any schema change — additive or breaking — does **not** require a version bump or migration function. Move fast and iterate freely.
 
-Once v1.0.0 is published to the VS Code Marketplace, any breaking change to the echo format requires:
+Once v1.0.0 is published to the VS Code Marketplace, breaking changes to the echo format require:
 1. A schema version bump (e.g. `"1.1"`)
 2. A migration function in `src/echo/echo.ts` that upgrades older files on read
 3. An update to `ECHO_VERSION` in `src/types/echo.ts`
 
-New step types added after release are always additive and do not require migration, as long as older players can safely ignore unknown step types (the `default` case in the `switch` handles this).
+Purely additive changes after release (new optional step types, new optional fields) remain safe without migration, as long as older players silently skip unknown step types via the `default` case in the player `switch`.
 
 ## Testing Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thank you for contributing! This document outlines our contribution and testing policy.
 
+## Code Tours
+
+The `.tours/` directory contains [CodeTour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) files for VS Code. Install the CodeTour extension and run **CodeTour: Start Tour** to explore:
+
+- **Architecture Overview** — module structure and core concepts; start here if you are new to the codebase
+- **Adding a New Step Type** — step-by-step guide for implementing a new echo step type (uses the `focus` step as a worked example)
+
+**Keeping tours current:** tour steps reference specific line numbers. If you significantly change a file that a tour references (e.g. restructure `player.ts`, rename a function in `echo.ts`), check whether the tour step still points to the right place and update the line number if needed. The affected file is listed in each `.tour` JSON step's `"file"` field.
+
 ## Echo Schema Changes
 
 The echo format lives in `schemas/gecho-v1.schema.json` and `src/types/echo.ts`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ The echo format lives in `schemas/gecho-v1.schema.json` and `src/types/echo.ts`.
 
 **Before the v1.0.0 extension release**, any schema change — additive or breaking — does **not** require a version bump or migration function. Move fast and iterate freely.
 
-Once v1.0.0 is published to the VS Code Marketplace, breaking changes to the echo format require:
+Once v1.0.0 is published to the VS Code Marketplace, changes to the echo format that affect what older versions must read require:
 1. A schema version bump (e.g. `"1.1"`)
 2. A migration function in `src/echo/echo.ts` that upgrades older files on read
 3. An update to `ECHO_VERSION` in `src/types/echo.ts`
 
-Purely additive changes after release (new optional step types, new optional fields) remain safe without migration, as long as older players silently skip unknown step types via the `default` case in the player `switch`.
+Do **not** assume purely additive changes after release (for example, new optional step types or new optional fields) are automatically safe without migration. Older versions may reject unknown step types during echo validation before replay reaches the player's `default` case, so post-release format changes should include a version bump and migration whenever backward compatibility matters.
 
 ## Testing Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Thank you for contributing! This document outlines our contribution and testing policy.
 
+## Echo Schema Changes
+
+The echo format lives in `schemas/gecho-v1.schema.json` and `src/types/echo.ts`.
+
+**Before the v1.0.0 extension release**, additive schema changes (new step types, new optional fields) do **not** require a version bump or migration function. The schema version string stays at `"1.0"` and existing echo files remain valid.
+
+Once v1.0.0 is published to the VS Code Marketplace, any breaking change to the echo format requires:
+1. A schema version bump (e.g. `"1.1"`)
+2. A migration function in `src/echo/echo.ts` that upgrades older files on read
+3. An update to `ECHO_VERSION` in `src/types/echo.ts`
+
+New step types added after release are always additive and do not require migration, as long as older players can safely ignore unknown step types (the `default` case in the `switch` handles this).
+
 ## Testing Requirements
 
 **All contributions must include tests.** This is a hard requirement:

--- a/docs/echo-reference.md
+++ b/docs/echo-reference.md
@@ -40,7 +40,7 @@ gEcho echoes are human-readable JSON files with a `.echo.json` extension. They d
 
 ## Step Types
 
-Every step object has a `type` field that determines its behavior. There are 8 step types.
+Every step object has a `type` field that determines its behavior. There are 9 step types.
 
 ---
 
@@ -226,6 +226,34 @@ Scrolls the active editor up or down by a specified number of lines.
 
 ---
 
+### `focus` — Move Focus to a UI Area
+
+Moves keyboard focus to a named VS Code UI area. Use this after `command` or `key` steps that shift focus away from the editor (e.g. opening the Command Palette, toggling the terminal).
+
+```json
+{ "type": "focus", "target": "editor" }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"focus"` | ✅ | Step type identifier. |
+| `target` | `"editor"` \| `"terminal"` \| `"panel"` \| `"sidebar"` | ✅ | UI area to focus. |
+
+**Targets:**
+
+| Target | VS Code action |
+|--------|----------------|
+| `editor` | Focus the active editor group — use this to restore text-editor focus so subsequent `type`/`select`/`paste`/`scroll` steps land in the right place. |
+| `terminal` | Focus the integrated terminal. |
+| `panel` | Focus the bottom panel (Output, Problems, etc.). |
+| `sidebar` | Focus the primary side bar (Explorer, Search, etc.). |
+
+**Notes:**
+- Insert a `{ "type": "focus", "target": "editor" }` step whenever a prior `command` or `key` step may have moved focus away from the editor and you want subsequent keystrokes to target the text pane.
+- The VS Code API does not expose which widget currently holds keyboard focus, so gEcho cannot auto-insert focus steps — authors must add them manually where needed.
+
+---
+
 ## JSON Schema
 
 gEcho ships with a JSON Schema at `schemas/gecho-v1.schema.json`. VS Code automatically validates `.echo.json` files against this schema, providing IntelliSense, auto-completion, and error highlighting as you edit echoes.
@@ -247,6 +275,7 @@ A complete example echo demonstrating all step types is available at [`echoes/ex
     { "type": "wait", "ms": 500 },
     { "type": "type", "text": "// Hello from gEcho!", "delay": 55 },
     { "type": "command", "id": "workbench.action.files.save" },
+    { "type": "focus", "target": "editor" },
     { "type": "select", "anchor": [0, 0], "active": [0, 20] },
     { "type": "key", "key": "escape" },
     { "type": "paste", "text": "// Pasted text" },
@@ -264,3 +293,4 @@ A complete example echo demonstrating all step types is available at [`echoes/ex
 - **End with a `wait`** so the final state is visible in the GIF output.
 - **Keep `delay` values between 30–80 ms** for natural-looking typing in GIFs.
 - **Use `paste`** for large code blocks to avoid lengthy typing animations.
+- **Insert `focus` steps** after any `command` or `key` that shifts focus away from the editor (e.g., after `workbench.action.terminal.toggleTerminal`, add `{ "type": "focus", "target": "editor" }` before the next `type` or `select` step).

--- a/docs/echo-reference.md
+++ b/docs/echo-reference.md
@@ -256,7 +256,7 @@ Moves keyboard focus to a named VS Code UI area. Use this after `command` or `ke
 
 ## JSON Schema
 
-gEcho ships with a JSON Schema at `schemas/gecho-v1.schema.json`. VS Code automatically validates `.echo.json` files against this schema, providing IntelliSense, auto-completion, and error highlighting as you edit echoes.
+gEcho ships with a JSON Schema at `schemas/gecho-v1.schema.json`. VS Code automatically validates `.echo.json` files (current extension) and `.gecho.json` files (legacy extension, supported for backward compatibility) against this schema, providing IntelliSense, auto-completion, and error highlighting as you edit echoes.
 
 ## Example Echo
 

--- a/echoes/example.echo.json
+++ b/echoes/example.echo.json
@@ -10,6 +10,7 @@
     { "type": "wait", "ms": 500 },
     { "type": "type", "text": "// Hello from gEcho!", "delay": 55 },
     { "type": "command", "id": "workbench.action.files.save" },
+    { "type": "focus", "target": "editor" },
     { "type": "select", "anchor": [0, 0], "active": [0, 20] },
     { "type": "key", "key": "escape" },
     { "type": "paste", "text": "// Pasted text" },

--- a/schemas/gecho-v1.schema.json
+++ b/schemas/gecho-v1.schema.json
@@ -77,7 +77,8 @@
         { "$ref": "#/$defs/WaitStep" },
         { "$ref": "#/$defs/OpenFileStep" },
         { "$ref": "#/$defs/PasteStep" },
-        { "$ref": "#/$defs/ScrollStep" }
+        { "$ref": "#/$defs/ScrollStep" },
+        { "$ref": "#/$defs/FocusStep" }
       ]
     },
     "TypeStep": {
@@ -273,6 +274,24 @@
           "type": "integer",
           "minimum": 1,
           "description": "Number of lines to scroll"
+        }
+      }
+    },
+    "FocusStep": {
+      "type": "object",
+      "required": ["type", "target"],
+      "additionalProperties": false,
+      "description": "Move keyboard focus to a named VS Code UI area",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "focus",
+          "description": "Step type identifier"
+        },
+        "target": {
+          "type": "string",
+          "enum": ["editor", "terminal", "panel", "sidebar"],
+          "description": "UI area to focus: 'editor' (active editor group), 'terminal' (integrated terminal), 'panel' (bottom panel), 'sidebar' (primary side bar)"
         }
       }
     }

--- a/src/echo/echo.ts
+++ b/src/echo/echo.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import type { Echo } from '../types/index.js';
+import { isFocusTarget } from '../types/index.js';
 
 export async function readEcho(filePath: string): Promise<Echo> {
   const raw = await readFile(filePath, 'utf-8');
@@ -72,6 +73,8 @@ function isValidStep(step: unknown): boolean {
     case 'scroll':
       return typeof s['lines'] === 'number' &&
              (s['direction'] === 'up' || s['direction'] === 'down');
+    case 'focus':
+      return isFocusTarget(s['target']);
     default:
       return false;
   }

--- a/src/replay/player.ts
+++ b/src/replay/player.ts
@@ -208,6 +208,20 @@ export class EchoPlayer {
               break;
             }
 
+            case 'focus': {
+              const FOCUS_COMMANDS: Record<string, string> = {
+                editor: 'workbench.action.focusActiveEditorGroup',
+                terminal: 'workbench.action.terminal.focus',
+                panel: 'workbench.action.focusPanel',
+                sidebar: 'workbench.action.focusSideBar',
+              };
+              const cmd = FOCUS_COMMANDS[step.target];
+              if (cmd) {
+                await vscode.commands.executeCommand(cmd);
+              }
+              break;
+            }
+
             default: {
               break;
             }

--- a/src/replay/player.ts
+++ b/src/replay/player.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { Echo, ReplayConfig } from '../types/index.js';
+import type { Echo, FocusTarget, ReplayConfig } from '../types/index.js';
 import { sanitizeCommandId, sanitizeFilePath } from '../security/index.js';
 
 const DEFAULT_CHAR_DELAY_MS = 55;
@@ -25,6 +25,14 @@ const KEY_COMMAND_MAP: Record<string, string> = {
   'escape': 'cancelSelection',
   'tab': 'tab',
   'enter': 'acceptSelectedSuggestion',
+};
+
+/** Maps focus targets to their VS Code command IDs */
+const FOCUS_COMMANDS: Record<FocusTarget, string> = {
+  editor: 'workbench.action.focusActiveEditorGroup',
+  terminal: 'workbench.action.terminal.focus',
+  panel: 'workbench.action.focusPanel',
+  sidebar: 'workbench.action.focusSideBar',
 };
 
 export class EchoPlayer {
@@ -209,16 +217,7 @@ export class EchoPlayer {
             }
 
             case 'focus': {
-              const FOCUS_COMMANDS: Record<string, string> = {
-                editor: 'workbench.action.focusActiveEditorGroup',
-                terminal: 'workbench.action.terminal.focus',
-                panel: 'workbench.action.focusPanel',
-                sidebar: 'workbench.action.focusSideBar',
-              };
-              const cmd = FOCUS_COMMANDS[step.target];
-              if (cmd) {
-                await vscode.commands.executeCommand(cmd);
-              }
+              await vscode.commands.executeCommand(FOCUS_COMMANDS[step.target]);
               break;
             }
 

--- a/src/types/echo.ts
+++ b/src/types/echo.ts
@@ -45,6 +45,11 @@ export interface ScrollStep {
   lines: number;
 }
 
+export interface FocusStep {
+  type: 'focus';
+  target: 'editor' | 'terminal' | 'panel' | 'sidebar';
+}
+
 export type StepType =
   | TypeStep
   | CommandStep
@@ -53,7 +58,8 @@ export type StepType =
   | WaitStep
   | OpenFileStep
   | PasteStep
-  | ScrollStep;
+  | ScrollStep
+  | FocusStep;
 
 export interface EchoMetadata {
   name: string;

--- a/src/types/echo.ts
+++ b/src/types/echo.ts
@@ -45,9 +45,16 @@ export interface ScrollStep {
   lines: number;
 }
 
+export const FOCUS_TARGETS = ['editor', 'terminal', 'panel', 'sidebar'] as const;
+export type FocusTarget = (typeof FOCUS_TARGETS)[number];
+
+export function isFocusTarget(value: unknown): value is FocusTarget {
+  return typeof value === 'string' && (FOCUS_TARGETS as readonly string[]).includes(value);
+}
+
 export interface FocusStep {
   type: 'focus';
-  target: 'editor' | 'terminal' | 'panel' | 'sidebar';
+  target: FocusTarget;
 }
 
 export type StepType =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,11 +7,13 @@ export type {
   OpenFileStep,
   PasteStep,
   ScrollStep,
+  FocusStep,
+  FocusTarget,
   StepType,
   EchoMetadata,
   Echo,
 } from './echo.js';
-export { ECHO_VERSION, ECHO_FILE_EXTENSION } from './echo.js';
+export { ECHO_VERSION, ECHO_FILE_EXTENSION, FOCUS_TARGETS, isFocusTarget } from './echo.js';
 
 export type {
   RecordingMode,

--- a/test/suite/echo.test.ts
+++ b/test/suite/echo.test.ts
@@ -24,6 +24,7 @@ function makeFullEcho(): Echo {
     { type: 'openFile', path: 'src/main.ts' },
     { type: 'paste', text: 'pasted text' },
     { type: 'scroll', direction: 'down', lines: 3 },
+    { type: 'focus', target: 'editor' },
   ];
   return {
     version: '1.0',
@@ -84,6 +85,23 @@ describe('validateEcho', () => {
       metadata: { name: 'x' },
       steps: [{ type: 'scroll', lines: 3, direction: 'sideways' }],
     };
+    assert.strictEqual(validateEcho(bad), false);
+  });
+
+  it('returns true for focus step with valid target', () => {
+    for (const target of ['editor', 'terminal', 'panel', 'sidebar']) {
+      const echo = { version: '1.0', metadata: { name: 'x' }, steps: [{ type: 'focus', target }] };
+      assert.strictEqual(validateEcho(echo), true, `Expected valid for target: ${target}`);
+    }
+  });
+
+  it('returns false for focus step with invalid target', () => {
+    const bad = { version: '1.0', metadata: { name: 'x' }, steps: [{ type: 'focus', target: 'statusbar' }] };
+    assert.strictEqual(validateEcho(bad), false);
+  });
+
+  it('returns false for focus step missing target', () => {
+    const bad = { version: '1.0', metadata: { name: 'x' }, steps: [{ type: 'focus' }] };
     assert.strictEqual(validateEcho(bad), false);
   });
 });

--- a/test/suite/player.test.ts
+++ b/test/suite/player.test.ts
@@ -239,69 +239,28 @@ describe('EchoPlayer', () => {
       }
     });
 
-    it('focus step with target "editor" executes focusActiveEditorGroup', async () => {
-      const calls: string[] = [];
-      const orig = (vscode.commands as any).executeCommand;
-      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
-      try {
-        const player = new EchoPlayer();
-        await player.play({
-          version: '1.0', metadata: { name: 't' },
-          steps: [{ type: 'focus', target: 'editor' }],
-        });
-        assert.deepStrictEqual(calls, ['workbench.action.focusActiveEditorGroup']);
-      } finally {
-        (vscode.commands as any).executeCommand = orig;
-      }
-    });
-
-    it('focus step with target "terminal" executes terminal.focus', async () => {
-      const calls: string[] = [];
-      const orig = (vscode.commands as any).executeCommand;
-      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
-      try {
-        const player = new EchoPlayer();
-        await player.play({
-          version: '1.0', metadata: { name: 't' },
-          steps: [{ type: 'focus', target: 'terminal' }],
-        });
-        assert.deepStrictEqual(calls, ['workbench.action.terminal.focus']);
-      } finally {
-        (vscode.commands as any).executeCommand = orig;
-      }
-    });
-
-    it('focus step with target "panel" executes focusPanel', async () => {
-      const calls: string[] = [];
-      const orig = (vscode.commands as any).executeCommand;
-      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
-      try {
-        const player = new EchoPlayer();
-        await player.play({
-          version: '1.0', metadata: { name: 't' },
-          steps: [{ type: 'focus', target: 'panel' }],
-        });
-        assert.deepStrictEqual(calls, ['workbench.action.focusPanel']);
-      } finally {
-        (vscode.commands as any).executeCommand = orig;
-      }
-    });
-
-    it('focus step with target "sidebar" executes focusSideBar', async () => {
-      const calls: string[] = [];
-      const orig = (vscode.commands as any).executeCommand;
-      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
-      try {
-        const player = new EchoPlayer();
-        await player.play({
-          version: '1.0', metadata: { name: 't' },
-          steps: [{ type: 'focus', target: 'sidebar' }],
-        });
-        assert.deepStrictEqual(calls, ['workbench.action.focusSideBar']);
-      } finally {
-        (vscode.commands as any).executeCommand = orig;
-      }
-    });
+    for (const { target, expectedCommand } of [
+      { target: 'editor' as const, expectedCommand: 'workbench.action.focusActiveEditorGroup' },
+      { target: 'terminal' as const, expectedCommand: 'workbench.action.terminal.focus' },
+      { target: 'panel' as const, expectedCommand: 'workbench.action.focusPanel' },
+      { target: 'sidebar' as const, expectedCommand: 'workbench.action.focusSideBar' },
+    ]) {
+      it(`focus step with target "${target}" executes correct command`, async () => {
+        const calls: string[] = [];
+        const orig = (vscode.commands as any).executeCommand;
+        (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
+        try {
+          const player = new EchoPlayer();
+          await player.play({
+            version: '1.0', metadata: { name: 't' },
+            steps: [{ type: 'focus', target }],
+          });
+          assert.deepStrictEqual(calls, [expectedCommand]);
+        } finally {
+          (vscode.commands as any).executeCommand = orig;
+        }
+      });
+    }
 
     it('select step does not throw when no active editor', async () => {
       const player = new EchoPlayer();

--- a/test/suite/player.test.ts
+++ b/test/suite/player.test.ts
@@ -239,6 +239,70 @@ describe('EchoPlayer', () => {
       }
     });
 
+    it('focus step with target "editor" executes focusActiveEditorGroup', async () => {
+      const calls: string[] = [];
+      const orig = (vscode.commands as any).executeCommand;
+      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
+      try {
+        const player = new EchoPlayer();
+        await player.play({
+          version: '1.0', metadata: { name: 't' },
+          steps: [{ type: 'focus', target: 'editor' }],
+        });
+        assert.deepStrictEqual(calls, ['workbench.action.focusActiveEditorGroup']);
+      } finally {
+        (vscode.commands as any).executeCommand = orig;
+      }
+    });
+
+    it('focus step with target "terminal" executes terminal.focus', async () => {
+      const calls: string[] = [];
+      const orig = (vscode.commands as any).executeCommand;
+      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
+      try {
+        const player = new EchoPlayer();
+        await player.play({
+          version: '1.0', metadata: { name: 't' },
+          steps: [{ type: 'focus', target: 'terminal' }],
+        });
+        assert.deepStrictEqual(calls, ['workbench.action.terminal.focus']);
+      } finally {
+        (vscode.commands as any).executeCommand = orig;
+      }
+    });
+
+    it('focus step with target "panel" executes focusPanel', async () => {
+      const calls: string[] = [];
+      const orig = (vscode.commands as any).executeCommand;
+      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
+      try {
+        const player = new EchoPlayer();
+        await player.play({
+          version: '1.0', metadata: { name: 't' },
+          steps: [{ type: 'focus', target: 'panel' }],
+        });
+        assert.deepStrictEqual(calls, ['workbench.action.focusPanel']);
+      } finally {
+        (vscode.commands as any).executeCommand = orig;
+      }
+    });
+
+    it('focus step with target "sidebar" executes focusSideBar', async () => {
+      const calls: string[] = [];
+      const orig = (vscode.commands as any).executeCommand;
+      (vscode.commands as any).executeCommand = async (cmd: string) => { calls.push(cmd); };
+      try {
+        const player = new EchoPlayer();
+        await player.play({
+          version: '1.0', metadata: { name: 't' },
+          steps: [{ type: 'focus', target: 'sidebar' }],
+        });
+        assert.deepStrictEqual(calls, ['workbench.action.focusSideBar']);
+      } finally {
+        (vscode.commands as any).executeCommand = orig;
+      }
+    });
+
     it('select step does not throw when no active editor', async () => {
       const player = new EchoPlayer();
       // activeTextEditor is undefined in plain test host — step is silently skipped


### PR DESCRIPTION
## Problem

Fixes #87. When a `command` or `key` step shifts keyboard focus away from the text editor (e.g. opens the Command Palette, toggles the terminal), subsequent `type`, `select`, `paste`, and `scroll` steps silently fail or type into the wrong widget. VS Code's `executeCommand('type', ...)` delivers keystrokes to whichever widget currently has focus, so there's no automatic way for the player to know focus has moved.

## Solution

Add a new `focus` step type that explicitly moves keyboard focus to a named VS Code UI area:

```json
{ "type": "focus", "target": "editor" }
```

**Targets:**

| Target | VS Code command |
|--------|----------------|
| `editor` | `workbench.action.focusActiveEditorGroup` |
| `terminal` | `workbench.action.terminal.focus` |
| `panel` | `workbench.action.focusPanel` |
| `sidebar` | `workbench.action.focusSideBar` |

Echo authors insert `focus` steps wherever a prior command shifts focus and subsequent steps need to target a specific area. The most common pattern is:

```json
{ "type": "command", "id": "workbench.action.terminal.toggleTerminal" },
{ "type": "focus", "target": "editor" },
{ "type": "type", "text": "// back in the editor" }
```

## Changes

- **`src/types/echo.ts`** — `FocusStep` interface + added to `StepType` union
- **`schemas/gecho-v1.schema.json`** — `FocusStep` definition in `oneOf`
- **`src/replay/player.ts`** — `focus` case in the step `switch`
- **`docs/echo-reference.md`** — Full documentation for the new step type + authoring tip
- **`CONTRIBUTING.md`** — Schema migration policy (pre-v1.0.0 additive changes need no migration)
- **`test/suite/player.test.ts`** — 4 dispatch tests covering all targets

## Why not auto-refocus?

Auto-refocusing before editor-bound steps would break echoes that intentionally type into the Command Palette or Quick Pick after a `key: 'cmd+shift+p'` step. Explicit `focus` steps give authors full control without surprising side effects.