### PR TITLE
docs: Add CodeTour walkthroughs for contributors

### DIFF
--- a/.tours/adding-a-step-type.tour
+++ b/.tours/adding-a-step-type.tour
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Adding a New Step Type",
+  "description": "A contributor guide for implementing a new echo step type. Uses the `scroll` step as a worked example. Follow these steps in order — all 7 must be completed.",
+  "steps": [
+    {
+      "file": "src/types/echo.ts",
+      "line": 42,
+      "title": "Step 1 — Define the TypeScript interface",
+      "description": "Define your new step interface here, next to the existing ones. The `scroll` step is a good reference — it has a required typed enum field (`direction`) and a numeric field:\n\n```typescript\nexport interface MyStep {\n  type: 'myStep';\n  // ...fields\n}\n```\n\nIf your step has a field constrained to a fixed set of values, consider modelling it as a `const` tuple + type alias + type guard (similar to the `direction: 'up' | 'down'` inline union here, but extracted when the list is long or reused by the validator)."
+    },
+    {
+      "file": "src/types/echo.ts",
+      "line": 48,
+      "title": "Step 2 — Add to the StepType union",
+      "description": "Add your new interface to the `StepType` discriminated union:\n\n```typescript\nexport type StepType =\n  | TypeStep\n  | ...\n  | MyStep;   // ← add here\n```\n\nTypeScript will now flag any exhaustive switch (like the one in the player) that is missing your new case. Fix those before moving on."
+    },
+    {
+      "file": "src/types/index.ts",
+      "line": 1,
+      "title": "Step 3 — Re-export from the types barrel",
+      "description": "Add your new type (and any companion constants/guards) to the re-export list in `src/types/index.ts`.\n\n- Interface types go in the `export type { ... }` block\n- Runtime values (const arrays, type guard functions) go in the `export { ... }` block\n\nThis ensures other modules can import from `'../types/index.js'` without reaching into `'../types/echo.js'` directly."
+    },
+    {
+      "file": "schemas/gecho-v1.schema.json",
+      "line": 256,
+      "title": "Step 4 — Add JSON Schema definition",
+      "description": "Add a `$defs` entry for your new step type and reference it in the `Step.oneOf` array (around line 72).\n\nThe `scroll` step definition here is a good template — `additionalProperties: false` keeps the schema tight, and `const` on the `type` field is what makes `oneOf` discrimination work:\n\n```json\n\"MyStep\": {\n  \"type\": \"object\",\n  \"required\": [\"type\", \"myField\"],\n  \"additionalProperties\": false,\n  \"description\": \"What this step does\",\n  \"properties\": {\n    \"type\": { \"type\": \"string\", \"const\": \"myStep\" },\n    \"myField\": { ... }\n  }\n}\n```\n\nThen add `{ \"$ref\": \"#/$defs/MyStep\" }` to the `oneOf` list.\n\nBefore v1.0.0 release, no schema version bump or migration is needed for any change."
+    },
+    {
+      "file": "src/echo/echo.ts",
+      "line": 72,
+      "title": "Step 5 — Add to isValidStep()",
+      "description": "Add a `case` for your new step type in `isValidStep()`. This is the runtime guard that `readEcho()` uses — without it, any echo file containing your new step will throw `\"Invalid echo format\"`.\n\nThe `scroll` case here shows validating both a number and an enum string:\n```typescript\ncase 'myStep':\n  return typeof s['myField'] === 'string';\n```\n\nFor constrained fields, import and use your type guard instead of a raw string check for a single source of truth."
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 202,
+      "title": "Step 6 — Handle in EchoPlayer",
+      "description": "Add a `case` to the step `switch` in `EchoPlayer.play()`. The `scroll` case dispatches a single `executeCommand` with structured args — a common pattern.\n\nKey rules:\n- If your step takes a user-supplied command ID, call `sanitizeCommandId()` first\n- If your step takes a user-supplied file path, call `sanitizeFilePath()` first\n- If your step maps a typed enum to VS Code commands, hoist a `Record<MyTarget, string>` constant to module level (typed against your enum, not `Record<string, string>`) for compile-time exhaustiveness\n\nThe `default` case is intentionally a no-op — older players skip unknown step types gracefully when replaying newer echo files."
+    },
+    {
+      "file": "docs/echo-reference.md",
+      "line": 43,
+      "title": "Step 7 — Document it",
+      "description": "Update `docs/echo-reference.md`:\n\n1. Increment the step type count in the intro paragraph (currently `8 step types`)\n2. Add a new `### \\`myStep\\` — Title` section following the existing pattern (JSON example, field table, Notes)\n3. Add your step to the example echo at the bottom of the file\n4. Add an authoring tip if relevant\n\nAlso check `echoes/example.echo.json` — if it demonstrates all step types, add yours there too."
+    }
+  ]
+}

--- a/.tours/architecture-overview.tour
+++ b/.tours/architecture-overview.tour
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Architecture Overview",
+  "description": "A guided walkthrough of gEcho's module structure and core concepts. Start here if you are new to the codebase.",
+  "steps": [
+    {
+      "file": "src/types/echo.ts",
+      "line": 48,
+      "title": "1. The Echo Format — StepType Union",
+      "description": "Every echo is a sequence of `StepType` steps. The union is a **discriminated union** on the `type` string literal — this is the central data contract of the whole extension.\n\nAll step types are defined in this file. When you add a new step type, this is your first stop. The `default` case in the player's switch statement must always handle unknown steps (exhaustiveness check).\n\nThe echo format itself is a `.echo.json` file: `{ version, metadata, steps[] }`. See `schemas/gecho-v1.schema.json` for the JSON Schema definition."
+    },
+    {
+      "file": "src/echo/echo.ts",
+      "line": 25,
+      "title": "2. Echo I/O — validateEcho",
+      "description": "`validateEcho()` is a runtime type guard that checks every field and step before trusting the data. It is called by `readEcho()` before returning an `Echo` to callers.\n\nThe `isValidStep()` function below it has a `switch` mirroring the `StepType` union — every new step type must be added to both.\n\nThis module has **no VS Code dependency** — it is pure Node.js `fs/promises` and is tested by plain Mocha without an Extension Host."
+    },
+    {
+      "file": "src/recording/recorder.ts",
+      "line": 7,
+      "title": "3. Recording — EchoRecorder",
+      "description": "`EchoRecorder` listens to three VS Code events and translates them into `StepType[]`:\n\n- `onDidChangeTextDocument` → `TypeStep` (with coalescing of adjacent single-char inserts)\n- `onDidChangeTextEditorSelection` → `SelectStep`\n- `onDidChangeActiveTextEditor` → `OpenFileStep`\n\nCall `start()` to begin recording, `stop()` to receive the collected steps. The recorder is **stateless between sessions** — `start()` resets everything.\n\nNote: The VS Code API does not expose mouse events or widget-level focus changes, so those cannot be recorded automatically."
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 30,
+      "title": "4. Replay — EchoPlayer",
+      "description": "`EchoPlayer` is the inverse of `EchoRecorder`. It takes a `StepType[]` and executes each step against the VS Code API.\n\nKey behaviours:\n- **`cancelOnInput`**: if a real user types or clicks while replay is running, it stops. Implemented by watching `onDidChangeTextDocument` and `onDidChangeTextEditorSelection`.\n- **`speed`**: all delay values are divided by this multiplier.\n- **`isExecutingStep` flag**: guards the cancel listeners so they don't fire on the player's own programmatic changes."
+    },
+    {
+      "file": "src/replay/player.ts",
+      "line": 89,
+      "title": "5. Step Dispatch — The Switch Statement",
+      "description": "The core of the player is this `switch` on `step.type`. Each case maps one `StepType` to VS Code API calls.\n\nArchitectural rules enforced here:\n- `sanitizeCommandId()` must be called before every `executeCommand` that takes a step-supplied ID\n- `sanitizeFilePath()` must be called before every file open that takes a step-supplied path\n- The `default` case is the exhaustiveness fallback — unknown step types are silently skipped so old players can replay newer echo files gracefully"
+    },
+    {
+      "file": "src/security/sanitizer.ts",
+      "line": 5,
+      "title": "6. Security — Sanitizers",
+      "description": "Three sanitizer functions guard all externally-supplied inputs:\n\n- **`sanitizeFilePath()`** — rejects path traversal (`../`), absolute paths outside the workspace\n- **`sanitizeCommandId()`** — allowlists command IDs to `[a-zA-Z0-9._-]+` only\n- **`sanitizeFfmpegPath()`** — validates the ffmpeg binary path\n\n**Architecture rule**: these must be called before every `executeCommand(step.id)`, every file open from an echo step, and every ffmpeg spawn. Skipping them is a security defect."
+    },
+    {
+      "file": "src/screen/capture.ts",
+      "line": 80,
+      "title": "7. Screen Capture — ScreenCapture",
+      "description": "`ScreenCapture` wraps ffmpeg for recording the VS Code window as a video file (later converted to GIF).\n\nPlatform-specific details:\n- **macOS**: AVFoundation device — index is dynamic, enumerated at runtime via `enumerateAvfDevices()` (cached as a Promise to avoid double-spawning)\n- **Linux**: x11grab\n- **Windows**: gdigrab\n\nThe class spawns ffmpeg as a child process. `stop()` sends SIGINT and waits for the process to exit cleanly.\n\n**All errors thrown from this file must begin with `'gEcho:'`** for consistency."
+    },
+    {
+      "file": "src/platform/platform.ts",
+      "line": 71,
+      "title": "8. Platform Layer — getWindowInfo",
+      "description": "`getWindowInfo()` resolves the VS Code window's pixel bounds and which display it is on. This is used by `ScreenCapture` to crop the ffmpeg input to just the VS Code window.\n\nIt spawns a platform-specific helper binary from `resources/bin/{platform}/gecho-helper*` (compiled separately — not a Node.js file). The result is **cached as a module-level Promise** so concurrent callers share one subprocess invocation.\n\nFallback: if the helper fails, bounds default to `{ x:0, y:0, width:1920, height:1080 }`."
+    },
+    {
+      "file": "src/config.ts",
+      "line": 4,
+      "title": "9. Configuration — getConfig",
+      "description": "`getConfig()` is the single access point for all `gecho.*` VS Code settings. Every feature reads configuration through here — no raw `vscode.workspace.getConfiguration()` calls scattered around the codebase.\n\nSettings are defined in `package.json` under `contributes.configuration`. The current settings cover: replay speed, cancelOnInput, output format, scale, crop, and startup/stop timeouts."
+    },
+    {
+      "file": "src/extension.ts",
+      "line": 75,
+      "title": "10. Entry Point — activate()",
+      "description": "`activate()` is the only entry point VS Code calls. It is intentionally thin: it registers commands, creates the status bar, and checks dependencies. All real logic lives in the modules above.\n\n**Activation policy**: gEcho activates only on `onCommand:gecho.*` — never on startup. Do not add `onStartupFinished` or `\"*\"` activation.\n\nThe module-level `currentState: RecordingState` and `active*` variables (recorder, player, capture) are the only global state. There is no separate state manager.\n\n`deactivate()` at the bottom of this file cleans up all three active objects."
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thank you for contributing! This document outlines our contribution and testing policy.
 
+## Code Tours
+
+The `.tours/` directory contains [CodeTour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) files for VS Code. Install the CodeTour extension and run **CodeTour: Start Tour** to explore:
+
+- **Architecture Overview** — module structure and core concepts; start here if you are new to the codebase
+- **Adding a New Step Type** — step-by-step guide for implementing a new echo step type (uses the `scroll` step as a worked example)
+
+**Keeping tours current:** tour steps reference specific line numbers. If you significantly change a file that a tour references, check whether the tour step still points to the right place and update the line number if needed. The affected file is listed in each `.tour` JSON step's `"file"` field.
+
 ## Testing Requirements
 
 **All contributions must include tests.** This is a hard requirement:


### PR DESCRIPTION
## Summary

Adds two [CodeTour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) files to help contributors navigate the gEcho codebase. Tours are plain JSON in `.tours/` — no build tooling required, just install the CodeTour VS Code extension and run **CodeTour: Start Tour**.

## Tours

### Architecture Overview (10 steps)
A module-by-module walkthrough for anyone new to the codebase:

> types → echo I/O → recorder → player → step dispatch → security sanitizers → screen capture → platform → config → `activate()`

Each step explains what the module does, its key constraints, and how it connects to the others.

### Adding a New Step Type (7 steps)
A contributor checklist using the `scroll` step as a worked example — covers every file that must be touched when implementing a new step type:

> interface definition → StepType union → barrel re-export → JSON schema → `isValidStep()` → player switch → docs

This directly supports ongoing issues like #55 (cursor step) and future mouse steps (#60).

## Also added
- **`CONTRIBUTING.md`**: new "Code Tours" section with install instructions and a note to keep line numbers current when referenced code changes.

## Maintenance strategy
All tour steps anchor to `class`/`export function`/`export const` definition lines — not logic internals — so they move infrequently. Descriptions are self-contained so a step being a line off is not critical.