### PR TITLE
docs: Sync documentation with recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Echoes are human-readable JSON files with a `.echo.json` extension:
 
 ## Requirements
 
-- **VS Code** 1.101.0 or later
+- **VS Code** 1.115.0 or later
 - **ffmpeg** installed and available in PATH ([install guide](https://ffmpeg.org/download.html))
 
 ## How It Works

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide walks you through installing gEcho, setting up ffmpeg, and creating y
 
 ### VS Code
 
-gEcho requires **VS Code 1.101.0** or later. Download it from [code.visualstudio.com](https://code.visualstudio.com/).
+gEcho requires **VS Code 1.115.0** or later. Download it from [code.visualstudio.com](https://code.visualstudio.com/).
 
 ### ffmpeg
 


### PR DESCRIPTION
Commit da744c73 bumped engines.vscode to ^1.115.0 to match @types/vscode, but README.md and docs/getting-started.md still referenced 1.101.0.